### PR TITLE
update minimum rustc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RINEX
 [![crates.io](https://docs.rs/rinex/badge.svg)](https://docs.rs/rinex/)
 [![crates.io](https://img.shields.io/crates/d/rinex.svg)](https://crates.io/crates/rinex)
 
-[![minimum rustc: 1.61](https://img.shields.io/badge/minimum%20rustc-1.61-blue?logo=rust)](https://www.whatrustisit.com)
+[![minimum rustc: 1.64](https://img.shields.io/badge/minimum%20rustc-1.64-blue?logo=rust)](https://www.whatrustisit.com)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-MIT) 
 

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["rinex", "gps", "glonass", "galileo", "timing"]
 categories = ["science", "science::geo", "command-line-interface", "command-line-utilities"]
 edition = "2021"
 readme = "README.md"
+rust-version = "1.64"
 
 [dependencies]
 log = "0.4"

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["rinex", "timing", "gps", "glonass", "galileo"]
 categories = ["science", "science::geo", "parsing"]
 edition = "2021"
 readme = "README.md"
-rust-version = "1.61"
+rust-version = "1.64"
 
 [features]
 default = [] # no features by default

--- a/rinex/README.md
+++ b/rinex/README.md
@@ -1,7 +1,7 @@
 # RINEX
 
 [![crates.io](https://img.shields.io/crates/v/rinex.svg)](https://crates.io/crates/rinex)
-[![rustc](https://img.shields.io/badge/rustc-1.61%2B-blue.svg)](https://img.shields.io/badge/rustc-1.61%2B-blue.svg)
+[![rustc](https://img.shields.io/badge/rustc-1.64%2B-blue.svg)](https://img.shields.io/badge/rustc-1.64%2B-blue.svg)
 [![crates.io](https://docs.rs/rinex/badge.svg)](https://docs.rs/rinex/badge.svg)
 
 *RINEX* is a crate in the *GeoRust* ecosystem that aims at supporting


### PR DESCRIPTION
The use of "indexmap"/"hashbrown" has increased the minimumt rustc required. 
I think it is tied to IONEX/maps operations.
The ionex infra will get finalized and aligned to latest work, so that probably will not last for long.