### PR TITLE
NAV V4: RINEX V4 navigation support

### DIFF
--- a/rinex/build.rs
+++ b/rinex/build.rs
@@ -89,13 +89,6 @@ pub struct NavHelper<'a> {
         }
         nav_file.write_all("      ],\n".as_bytes()).unwrap();
         nav_file.write_all("   }),\n".as_bytes()).unwrap();
-        //let rev_major = frame["version"]["major"]
-        //    .as_u64()
-        //    .unwrap()
-        //    as u8;
-        //nav_file
-        //    .write_all(key.as_str().as_bytes())
-        //    .unwrap();
     }
 
     nav_file
@@ -105,16 +98,6 @@ pub struct NavHelper<'a> {
     nav_file
         .write_all("}\n".as_bytes()) // lazy_static!
         .unwrap();
-
-    //        for k in content.keys() {
-    //            nav_file
-    //                .write_all(
-    //                    format!("                  (\"{}\",{}),\n", k, content[k]).as_bytes(),
-    //                )
-    //                .unwrap();
-    //        }
-    //        nav_file.write_all("            ]},\n".as_bytes()).unwrap();
-    //    }
 }
 
 fn main() {

--- a/rinex/build.rs
+++ b/rinex/build.rs
@@ -6,63 +6,115 @@ fn build_nav_database() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let nav_path = Path::new(&out_dir).join("nav_orbits.rs");
     let mut nav_file = std::fs::File::create(&nav_path).unwrap();
-    let nav_data = std::fs::read_to_string("db/NAV/orbits.json").unwrap();
-    let json: serde_json::Value = serde_json::from_str(&nav_data).unwrap();
-    let constellations = json.as_array().unwrap();
-    nav_file
-        .write_all("use lazy_static::lazy_static;\n\n".as_bytes())
-        .unwrap();
-    nav_file.write_all("#[derive(Debug)]\n".as_bytes()).unwrap();
-    nav_file
-        .write_all("pub struct NavOrbit {\n   pub constellation: &'static str,\n   pub revisions: Vec<NavRevision>,\n}\n\n".as_bytes())
-        .unwrap();
-    nav_file.write_all("#[derive(Debug)]\n".as_bytes()).unwrap();
-    nav_file
-        .write_all("pub struct NavRevision {\n   pub major: &'static str,\n   pub minor: &'static str,\n   pub items: Vec<(&'static str,&'static str)>,\n}\n\n".as_bytes())
-        .unwrap();
+
+    // read helper descriptor
+    let nav_descriptor = std::fs::read_to_string("db/NAV/orbits.json").unwrap();
+    // parse
+    let json: serde_json::Value = serde_json::from_str(&nav_descriptor).unwrap();
+
+    let nav_frames = json.as_array().unwrap();
+
+    let nav_content = "use lazy_static::lazy_static;
+use crate::version::Version;
+use crate::prelude::Constellation;
+use crate::navigation::NavMsgType;
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Eq, Ord)]
+pub struct NavHelper<'a> {
+    pub constellation: Constellation,
+    pub version: Version,
+    pub msg: NavMsgType,
+    pub items: Vec<(&'a str, &'a str)>,
+}
+
+// NAV FRAMES description, from RINEX standards
+";
+    nav_file.write_all(nav_content.as_bytes()).unwrap();
+
     nav_file.write_all("lazy_static! {\n".as_bytes()).unwrap();
+
+    nav_file.write_all("#[derive(Debug)]\n".as_bytes()).unwrap();
+
     nav_file
-        .write_all("   pub static ref NAV_ORBITS: Vec<NavOrbit> = vec![\n".as_bytes())
+        .write_all("   pub static ref NAV_ORBITS: Vec<NavHelper<'static>> = vec![ \n".as_bytes())
         .unwrap();
-    for constellation in constellations {
-        let c = constellation["constellation"].as_str().unwrap();
-        nav_file.write_all("      NavOrbit {\n".as_bytes()).unwrap();
+
+    for frame in nav_frames {
+        // grab all fields
+        let constellation = frame["constellation"].as_str().unwrap(); // mandatory
+
+        let major = frame["version"]["major"].as_u64().unwrap(); // major is mandatory
+
+        let minor = frame["version"]["minor"].as_u64().unwrap_or(0); // optionnal
+
+        let msg = frame["type"].as_str().unwrap_or("LNAV"); // default type
+
+        let items = frame["orbits"].as_object().unwrap(); // mandatory
+
+        // begin frame description
+        nav_file.write_all("   ( NavHelper {\n".as_bytes()).unwrap();
         nav_file
-            .write_all(format!("         constellation: \"{}\",\n", c).as_bytes())
+            .write_all(
+                format!(
+                    "      constellation: Constellation::from_str(\"{}\").unwrap(),\n",
+                    constellation
+                )
+                .as_bytes(),
+            )
             .unwrap();
         nav_file
-            .write_all("         revisions: vec![\n".as_bytes())
+            .write_all("      version: Version {\n".as_bytes())
             .unwrap();
-        for rev in constellation["revisions"].as_array().unwrap() {
-            nav_file
-                .write_all("            NavRevision {\n".as_bytes())
-                .unwrap();
-            let major = rev["revision"]["major"].as_u64().unwrap() as u8;
-            let minor = rev["revision"]["minor"].as_u64().unwrap_or(0) as u8;
-            nav_file
-                .write_all(format!("               major: \"{}\",\n", major).as_bytes())
-                .unwrap();
-            nav_file
-                .write_all(format!("               minor: \"{}\",\n", minor).as_bytes())
-                .unwrap();
-            nav_file
-                .write_all("               items: vec![\n".as_bytes())
-                .unwrap();
-            let content = rev["content"].as_object().unwrap();
-            for k in content.keys() {
-                nav_file
-                    .write_all(
-                        format!("                  (\"{}\",{}),\n", k, content[k]).as_bytes(),
-                    )
-                    .unwrap();
-            }
-            nav_file.write_all("            ]},\n".as_bytes()).unwrap();
-        }
-        nav_file.write_all("         ],\n".as_bytes()).unwrap();
+        nav_file
+            .write_all(format!("           major: {},\n", major).as_bytes())
+            .unwrap();
+        nav_file
+            .write_all(format!("           minor: {},\n", minor).as_bytes())
+            .unwrap();
         nav_file.write_all("      },\n".as_bytes()).unwrap();
+        nav_file
+            .write_all(
+                format!("      msg: NavMsgType::from_str(\"{}\").unwrap(),\n", msg).as_bytes(),
+            )
+            .unwrap();
+        // frame body description
+        nav_file
+            .write_all("      items: vec![ \n".as_bytes())
+            .unwrap();
+        for key in items.keys() {
+            nav_file
+                .write_all(format!("         (\"{}\",{}),\n", key, items[key]).as_bytes())
+                .unwrap();
+        }
+        nav_file.write_all("      ],\n".as_bytes()).unwrap();
+        nav_file.write_all("   }),\n".as_bytes()).unwrap();
+        //let rev_major = frame["version"]["major"]
+        //    .as_u64()
+        //    .unwrap()
+        //    as u8;
+        //nav_file
+        //    .write_all(key.as_str().as_bytes())
+        //    .unwrap();
     }
-    nav_file.write_all("   ];\n".as_bytes()).unwrap();
-    nav_file.write_all("}".as_bytes()).unwrap();
+
+    nav_file
+        .write_all("   ];\n".as_bytes()) // NAV_ORBITS vec![
+        .unwrap();
+
+    nav_file
+        .write_all("}\n".as_bytes()) // lazy_static!
+        .unwrap();
+
+    //        for k in content.keys() {
+    //            nav_file
+    //                .write_all(
+    //                    format!("                  (\"{}\",{}),\n", k, content[k]).as_bytes(),
+    //                )
+    //                .unwrap();
+    //        }
+    //        nav_file.write_all("            ]},\n".as_bytes()).unwrap();
+    //    }
 }
 
 fn main() {

--- a/rinex/db/NAV/orbits.json
+++ b/rinex/db/NAV/orbits.json
@@ -1,10 +1,10 @@
-[{
-    "constellation": "GPS",
-    "revisions": [{
-        "revision": {
+[
+    {
+        "constellation": "GPS",
+        "version": {
             "major": 1
         },
-        "content": {
+        "orbits": {
             "iode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -34,10 +34,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GPS",
+        "version": {
             "major": 2
         },
-        "content": {
+        "orbits": {
             "iode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -67,10 +68,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GPS",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "iode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -100,10 +102,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GPS",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "adot": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -135,15 +138,13 @@
             "t_tm": "f64",
             "wn_op": "f64"
         }
-    }]
-},
-{
-    "constellation": "GLO",
-    "revisions": [{
-        "revision": {
+    },
+    {
+        "constellation": "GLO",
+        "version": {
             "major": 1
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -159,10 +160,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GLO",
+        "version": {
             "major": 2
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -178,10 +180,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GLO",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -197,10 +200,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GLO",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -218,15 +222,13 @@
             "urai": "f64",
 			"almanacHealth": "health"
         }
-    }]
-},
-{
-    "constellation": "GAL",
-    "revisions": [{
-        "revision": {
+    },  
+    {
+        "constellation": "GAL",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "iodnav": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -258,10 +260,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GAL",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "iodnav": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -288,15 +291,13 @@
             "spare3": "xxxx",
             "t_tm": "f64"
         }
-    }]
-},
-{
-    "constellation": "QZS",
-    "revisions": [{
-        "revision": {
+    },
+    {
+        "constellation": "QZSS",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "iode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -326,10 +327,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "QZSS",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "iode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -357,15 +359,13 @@
             "t_tm": "f64",
             "fitInt": "f64"
         }
-    }]
-},
-{
-    "constellation": "BDS",
-    "revisions": [{
-        "revision": {
+    },
+    {
+        "constellation": "BeiDou",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "aode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -397,10 +397,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "BeiDou",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "aode": "f64",
             "crs": "f64",
             "deltaN": "f64",
@@ -428,15 +429,13 @@
             "t_tm": "f64",
             "aodc": "f64"
         }
-    }]
-},
-{
-    "constellation": "GEO",
-    "revisions": [{
-        "revision": {
+    },
+    {
+        "constellation": "GEO",
+        "version": {
             "major": 3
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -452,10 +451,11 @@
         }
     },
     {
-        "revision": {
+        "constellation": "GEO",
+        "version": {
             "major": 4
         },
-        "content": {
+        "orbits": {
             "satPosX": "f64",
             "velX": "f64",
             "accelX": "f64",
@@ -469,5 +469,5 @@
             "accelZ": "f64",
             "iodn": "f64"
         }
-    }]
-}]
+    }
+]

--- a/rinex/src/navigation/ephemeris.rs
+++ b/rinex/src/navigation/ephemeris.rs
@@ -119,7 +119,7 @@ impl Ephemeris {
             .insert(field.to_string(), OrbitItem::from(value));
     }
     /// Retrieve week counter, if such data exists.
-    pub fn get_weeks(&self) -> Option<u32> {
+    pub fn get_week(&self) -> Option<u32> {
         self.orbits.get("week").and_then(|field| field.as_u32())
     }
     /*
@@ -319,7 +319,7 @@ impl Ephemeris {
         let kepler = self.kepler()?;
         let perturbations = self.perturbations()?;
 
-        let weeks = self.get_weeks()?;
+        let weeks = self.get_week()?;
         let t0 = GPST_REF_EPOCH + Duration::from_days((weeks * 7).into());
         let toe = t0 + Duration::from_seconds(kepler.toe as f64);
         let t_k = (t_sv - toe).to_seconds();
@@ -467,7 +467,9 @@ fn parse_orbits(
             if content.trim().len() == 0 {
                 // omitted field
                 key_index += 1;
-                nb_missing -= 1;
+                if nb_missing > 0 {
+                    nb_missing -= 1;
+                }
                 line = rem.clone();
                 continue;
             }
@@ -584,7 +586,7 @@ mod test {
 
         assert_eq!(ephemeris.get_orbit_f64("idot"), Some(1.839362331110e-10));
         assert_eq!(ephemeris.get_orbit_f64("dataSrc"), Some(2.580000000000e+02));
-        assert_eq!(ephemeris.get_weeks(), Some(2111));
+        assert_eq!(ephemeris.get_week(), Some(2111));
 
         assert_eq!(ephemeris.get_orbit_f64("sisa"), Some(3.120000000000e+00));
         //assert_eq!(ephemeris.get_orbit_f64("health"), Some(0.000000000000e+00));
@@ -642,7 +644,7 @@ mod test {
         );
 
         assert_eq!(ephemeris.get_orbit_f64("idot"), Some(-0.940753471872e-09));
-        assert_eq!(ephemeris.get_weeks(), Some(782));
+        assert_eq!(ephemeris.get_week(), Some(782));
 
         assert_eq!(
             ephemeris.get_orbit_f64("svAccuracy"),
@@ -979,7 +981,7 @@ mod test {
                 "orbit perturbations setup failed"
             );
             assert!(
-                ephemeris.get_weeks().is_some(),
+                ephemeris.get_week().is_some(),
                 "missing week counter, context is faulty"
             );
 

--- a/rinex/src/navigation/orbits.rs
+++ b/rinex/src/navigation/orbits.rs
@@ -250,16 +250,10 @@ pub(crate) fn closest_nav_standards(
         //    algorithm: decreasing, starting from desired revision
         let items: Vec<_> = database
             .iter()
-            .filter_map(|item| {
-                let mut opt: Option<&NavHelper> = None;
-                if item.constellation == constellation {
-                    if item.msg == msg {
-                        if item.version == Version::new(major, minor) {
-                            opt = Some(item);
-                        }
-                    }
-                }
-                opt
+            .filter(|item| {
+                item.constellation == constellation
+                    && item.msg == msg
+                    && item.version == Version::new(major, minor)
             })
             .collect();
 

--- a/rinex/src/navigation/orbits.rs
+++ b/rinex/src/navigation/orbits.rs
@@ -1,11 +1,7 @@
-//! NAV Orbits description, spanning all revisions
-//! and constellations
-use crate::version;
-//use std::fmt::Display;
+//! NAV Orbits description, spanning all revisions and constellations
 use super::health;
-use crate::constellation::Constellation;
+use crate::version;
 use bitflags::bitflags;
-use itertools::Itertools;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -230,175 +226,225 @@ impl OrbitItem {
     }
 }
 
-/// Identifies closest (but older) revision contained in NAV database.   
-/// Closest content (in time) is used during record parsing to identify and sort data.
-/// Returns None if no database entries were found for requested constellation.
-/// Returns None if only newer revisions were identified: we prefer older revisions.
-pub fn closest_revision(
-    constell: Constellation,
-    desired_rev: version::Version,
-) -> Option<version::Version> {
-    let db = &NAV_ORBITS;
-    let revisions: Vec<_> = db
-        .iter() // match requested constellation
-        .filter(|rev| rev.constellation == constell.to_3_letter_code())
-        .map(|rev| &rev.revisions)
-        .flatten()
-        .collect();
-    if revisions.len() == 0 {
-        return None; // ---> constell not found in dB
-    }
-    let major_matches: Vec<_> = revisions
-        .iter()
-        .filter(|r| i8::from_str_radix(r.major, 10).unwrap() - desired_rev.major as i8 == 0)
-        .collect();
-    if major_matches.len() > 0 {
-        // --> desired_rev.major perfectly matched
-        // --> try to match desired_rev.minor perfectly
-        let minor_matches: Vec<_> = major_matches
+/*
+ * Identifies closest (but older) revision contained in NAV database.
+ * Closest content (in time) is used during record parsing to identify and sort data.
+ * Returns None
+ *   - if no database entries were found for requested constellation.
+ *   - or only newer revision exist : we prefer matching on older revisions
+ */
+pub(crate) fn closest_nav_standards(
+    constellation: Constellation,
+    revision: version::Version,
+    msg: NavMsgType,
+) -> Option<&'static NavHelper<'static>> {
+    let database = &NAV_ORBITS;
+    // start by trying to locate desired revision.
+    // On each mismatch, we decrement and try to match.
+    let (mut major, mut minor): (u8, u8) = revision.into();
+    loop {
+        // filter on both:
+        //  + Exact Constellation
+        //  + Exact NavMsgType
+        //  + Exact revision we're currently trying to locate
+        //    algorithm: decreasing, starting from desired revision
+        let items: Vec<_> = database
             .iter()
-            .filter(|r| i8::from_str_radix(r.minor, 10).unwrap() - desired_rev.minor as i8 == 0)
-            .collect();
-        if minor_matches.len() > 0 {
-            // [+] .major perfectly matched
-            // [+] .minor perfectly matched
-            //     -> item is unique (if dB declaration is correct)
-            //     -> return directly
-            let major = u8::from_str_radix(minor_matches[0].major, 10).unwrap();
-            let minor = u8::from_str_radix(minor_matches[0].minor, 10).unwrap();
-            Some(version::Version::new(major, minor))
-        } else {
-            // [+] .major perfectly matched
-            // [+] .minor not perfectly matched
-            //    --> use closest older minor revision
-            let mut to_sort: Vec<_> = major_matches
-                .iter()
-                .map(|r| {
-                    (
-                        u8::from_str_radix(r.major, 10).unwrap(), // to later build object
-                        u8::from_str_radix(r.minor, 10).unwrap(), // to later build object
-                        i8::from_str_radix(r.minor, 10).unwrap() - desired_rev.minor as i8, // for filter op
-                    )
-                })
-                .collect();
-            to_sort.sort_by(|a, b| b.2.cmp(&a.2)); // sort by delta value
-            let to_sort: Vec<_> = to_sort
-                .iter()
-                .filter(|r| r.2 < 0) // retain negative deltas : only older revisions
-                .collect();
-            Some(version::Version::new(to_sort[0].0, to_sort[0].1))
-        }
-    } else {
-        // ---> desired_rev.major not perfectly matched
-        // ----> use closest older major revision
-        let mut to_sort: Vec<_> = revisions
-            .iter()
-            .map(|r| {
-                (
-                    u8::from_str_radix(r.major, 10).unwrap(), // to later build object
-                    i8::from_str_radix(r.major, 10).unwrap() - desired_rev.major as i8, // for filter op
-                    u8::from_str_radix(r.minor, 10).unwrap(), // to later build object
-                    i8::from_str_radix(r.minor, 10).unwrap() - desired_rev.minor as i8, // for filter op
-                )
+            .filter_map(|item| {
+                let mut opt: Option<&NavHelper> = None;
+                if item.constellation == constellation {
+                    if item.msg == msg {
+                        if item.version == Version::new(major, minor) {
+                            opt = Some(item);
+                        }
+                    }
+                }
+                opt
             })
             .collect();
-        to_sort.sort_by(|a, b| b.1.cmp(&a.1)); // sort by major delta value
-        let to_sort: Vec<_> = to_sort
-            .iter()
-            .filter(|r| r.1 < 0) // retain negative deltas only : only older revisions
-            .collect();
-        if to_sort.len() > 0 {
-            // one last case:
-            //   several minor revisions for given closest major revision
-            //   --> prefer highest value
-            let mut to_sort: Vec<_> = to_sort
-                .iter()
-                .duplicates_by(|r| r.1) // identical major deltas
-                .collect();
-            to_sort.sort_by(|a, b| b.3.cmp(&a.3)); // sort by minor deltas
-            let last = to_sort.last().unwrap();
-            Some(version::Version::new(last.0, last.2))
+
+        if items.len() == 0 {
+            if minor == 0 {
+                // we're done with this major
+                // -> downgrade to previous major
+                //    we start @ minor = 10, which is
+                //    larger than most revisions we know
+                if major == 0 {
+                    // we're done: browsed all possibilities
+                    break;
+                } else {
+                    major -= 1;
+                    minor = 10;
+                }
+            } else {
+                minor -= 1;
+            }
         } else {
-            None // only newer revisions available,
-                 // older revisions are always prefered
+            return Some(items[0]);
         }
-    }
+    } // loop
+    None
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::str::FromStr;
     #[test]
-    fn test_db_orbits_sanity() {
-        for n in NAV_ORBITS.iter() {
-            let c = Constellation::from_str(n.constellation);
-            assert_eq!(c.is_ok(), true);
-            let c = c.unwrap();
-            for r in n.revisions.iter() {
-                let major = u8::from_str_radix(r.major, 10);
-                assert_eq!(major.is_ok(), true);
-                let minor = u8::from_str_radix(r.minor, 10);
-                assert_eq!(minor.is_ok(), true);
-                for item in r.items.iter() {
-                    let (k, v) = item;
-                    if !k.contains(&"spare") {
-                        let test = String::from("0.000E0"); // testdata
-                        let e = OrbitItem::new(v, &test, c);
-                        assert_eq!(e.is_ok(), true);
-                    }
+    fn orbit_database_sanity() {
+        for frame in NAV_ORBITS.iter() {
+            // Test data fields description
+            let constellation = frame.constellation;
+            for (key, value) in frame.items.iter() {
+                let fake_content: Option<String> = match value {
+                    &"f64" => Some(String::from("0.000")), // like we would parse it,
+                    &"u32" => Some(String::from("0.000")),
+                    &"u8" => Some(String::from("0.000")),
+                    &"spare" => None, // such fields are actually dropped
+                    _ => None,
+                };
+                if let Some(content) = fake_content {
+                    // Item construction, based on this descriptor, must work.
+                    // Like we use it when parsing..
+                    let e = OrbitItem::new(value, &content, constellation);
+                    assert!(
+                        e.is_ok() == true,
+                        "failed to build Orbit Item from (\"{}\", \"{}\", \"{}\")",
+                        key,
+                        value,
+                        constellation,
+                    );
                 }
             }
         }
     }
     #[test]
-    fn test_revision_finder() {
-        let found = closest_revision(Constellation::Mixed, version::Version::default());
-        assert_eq!(found, None); // Constellation::Mixed is not contained in db!
-                                 // test GPS 1.0
-        let target = version::Version::new(1, 0);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
-        // test GPS 4.0
-        let target = version::Version::new(4, 0);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(4, 0)));
-        // test GPS 1.1 ==> 1.0
-        let target = version::Version::new(1, 1);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
+    fn nav_standards_finder() {
+        // Constellation::Mixed is not contained in db!
+        assert_eq!(
+            closest_nav_standards(Constellation::Mixed, Version::default(), NavMsgType::LNAV),
+            None,
+            "Mixed GNSS constellation is or should not exist in the DB"
+        );
+
+        // Test existing (exact match) entries
+        for (constellation, rev, msg) in vec![
+            (Constellation::GPS, Version::new(1, 0), NavMsgType::LNAV),
+            (Constellation::GPS, Version::new(2, 0), NavMsgType::LNAV),
+            (Constellation::GPS, Version::new(4, 0), NavMsgType::LNAV),
+            (Constellation::Glonass, Version::new(2, 0), NavMsgType::LNAV),
+            (Constellation::Glonass, Version::new(3, 0), NavMsgType::LNAV),
+            (Constellation::Galileo, Version::new(3, 0), NavMsgType::LNAV),
+            (Constellation::Galileo, Version::new(4, 0), NavMsgType::LNAV),
+            (Constellation::QZSS, Version::new(3, 0), NavMsgType::LNAV),
+            (Constellation::QZSS, Version::new(4, 0), NavMsgType::LNAV),
+            (Constellation::BeiDou, Version::new(3, 0), NavMsgType::LNAV),
+            (Constellation::BeiDou, Version::new(4, 0), NavMsgType::LNAV),
+        ] {
+            let found = closest_nav_standards(constellation, rev, msg);
+            assert!(
+                found.is_some(),
+                "should have identified {}:V{} ({}) frame that actually exists in DB",
+                constellation,
+                rev,
+                msg
+            );
+
+            let standards = found.unwrap();
+            assert!(
+                standards.constellation == constellation,
+                "bad constellation identified \"{}\", expecting \"{}\"",
+                constellation,
+                standards.constellation
+            );
+            assert!(
+                standards.version == rev,
+                "should have matched {} V{} exactly, because it exists in DB",
+                constellation,
+                rev,
+            );
+        }
+
+        // Test cases where the nearest revision is used, not that exact revision
+        for (constellation, desired, expected, msg) in vec![
+            (
+                Constellation::GPS,
+                Version::new(5, 0),
+                Version::new(4, 0),
+                NavMsgType::LNAV,
+            ),
+            (
+                Constellation::GPS,
+                Version::new(4, 1),
+                Version::new(4, 0),
+                NavMsgType::LNAV,
+            ),
+            (
+                Constellation::Glonass,
+                Version::new(3, 4),
+                Version::new(3, 0),
+                NavMsgType::LNAV,
+            ),
+        ] {
+            let found = closest_nav_standards(constellation, desired, msg);
+            assert!(
+                found.is_some(),
+                "should have converged for \"{}\" V\"{}\" (\"{}\") to nearest frame revision",
+                constellation,
+                desired,
+                msg
+            );
+
+            let standards = found.unwrap();
+
+            assert!(
+                standards.constellation == constellation,
+                "bad constellation identified \"{}\", expecting \"{}\"",
+                constellation,
+                standards.constellation
+            );
+
+            assert!(
+                standards.version == expected,
+                "closest_nav_standards() converged to wrong revision {}:{}({}) while \"{}\" was expected", 
+                constellation,
+                desired,
+                msg,
+                expected);
+        }
+
+        // test downgraded matches
         // test GPS 1.2 ==> 1.0
-        let target = version::Version::new(1, 2);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
-        // test GPS 1.3 ==> 1.0
-        let target = version::Version::new(1, 3);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
-        // test GPS 1.4 ==> 1.0
-        let target = version::Version::new(1, 4);
-        let found = closest_revision(Constellation::GPS, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
-        // test GLO 4.2 ==> 4.0
-        let target = version::Version::new(4, 2);
-        let found = closest_revision(Constellation::Glonass, target);
-        assert_eq!(found, Some(version::Version::new(4, 0)));
-        // test GLO 1.4 ==> 1.0
-        let target = version::Version::new(1, 4);
-        let found = closest_revision(Constellation::Glonass, target);
-        assert_eq!(found, Some(version::Version::new(1, 0)));
-        // test BDS 1.0 ==> does not exist
-        let target = version::Version::new(1, 0);
-        let found = closest_revision(Constellation::BeiDou, target);
-        assert_eq!(found, None);
-        // test BDS 1.4 ==> does not exist
-        let target = version::Version::new(1, 4);
-        let found = closest_revision(Constellation::BeiDou, target);
-        assert_eq!(found, None);
-        // test BDS 2.0 ==> does not exist
-        let target = version::Version::new(2, 0);
-        let found = closest_revision(Constellation::BeiDou, target);
-        assert_eq!(found, None);
+        // let target = version::Version::new(1, 2);
+        // let found = closest_revision(Constellation::GPS, target);
+        // assert_eq!(found, Some(version::Version::new(1, 0)));
+        // // test GPS 1.3 ==> 1.0
+        // let target = version::Version::new(1, 3);
+        // let found = closest_revision(Constellation::GPS, target);
+        // assert_eq!(found, Some(version::Version::new(1, 0)));
+        // // test GPS 1.4 ==> 1.0
+        // let target = version::Version::new(1, 4);
+        // let found = closest_revision(Constellation::GPS, target);
+        // assert_eq!(found, Some(version::Version::new(1, 0)));
+        // // test GLO 4.2 ==> 4.0
+        // let target = version::Version::new(4, 2);
+        // let found = closest_revision(Constellation::Glonass, target);
+        // assert_eq!(found, Some(version::Version::new(4, 0)));
+        // // test GLO 1.4 ==> 1.0
+        // let target = version::Version::new(1, 4);
+        // let found = closest_revision(Constellation::Glonass, target);
+        // assert_eq!(found, Some(version::Version::new(1, 0)));
+        // // test BDS 1.0 ==> does not exist
+        // let target = version::Version::new(1, 0);
+        // let found = closest_revision(Constellation::BeiDou, target);
+        // assert_eq!(found, None);
+        // // test BDS 1.4 ==> does not exist
+        // let target = version::Version::new(1, 4);
+        // let found = closest_revision(Constellation::BeiDou, target);
+        // assert_eq!(found, None);
+        // // test BDS 2.0 ==> does not exist
+        // let target = version::Version::new(2, 0);
+        // let found = closest_revision(Constellation::BeiDou, target);
+        // assert_eq!(found, None);
     }
     #[test]
     fn test_db_item() {

--- a/rinex/src/navigation/orbits.rs
+++ b/rinex/src/navigation/orbits.rs
@@ -411,40 +411,6 @@ mod test {
                 msg,
                 expected);
         }
-
-        // test downgraded matches
-        // test GPS 1.2 ==> 1.0
-        // let target = version::Version::new(1, 2);
-        // let found = closest_revision(Constellation::GPS, target);
-        // assert_eq!(found, Some(version::Version::new(1, 0)));
-        // // test GPS 1.3 ==> 1.0
-        // let target = version::Version::new(1, 3);
-        // let found = closest_revision(Constellation::GPS, target);
-        // assert_eq!(found, Some(version::Version::new(1, 0)));
-        // // test GPS 1.4 ==> 1.0
-        // let target = version::Version::new(1, 4);
-        // let found = closest_revision(Constellation::GPS, target);
-        // assert_eq!(found, Some(version::Version::new(1, 0)));
-        // // test GLO 4.2 ==> 4.0
-        // let target = version::Version::new(4, 2);
-        // let found = closest_revision(Constellation::Glonass, target);
-        // assert_eq!(found, Some(version::Version::new(4, 0)));
-        // // test GLO 1.4 ==> 1.0
-        // let target = version::Version::new(1, 4);
-        // let found = closest_revision(Constellation::Glonass, target);
-        // assert_eq!(found, Some(version::Version::new(1, 0)));
-        // // test BDS 1.0 ==> does not exist
-        // let target = version::Version::new(1, 0);
-        // let found = closest_revision(Constellation::BeiDou, target);
-        // assert_eq!(found, None);
-        // // test BDS 1.4 ==> does not exist
-        // let target = version::Version::new(1, 4);
-        // let found = closest_revision(Constellation::BeiDou, target);
-        // assert_eq!(found, None);
-        // // test BDS 2.0 ==> does not exist
-        // let target = version::Version::new(2, 0);
-        // let found = closest_revision(Constellation::BeiDou, target);
-        // assert_eq!(found, None);
     }
     #[test]
     fn test_db_item() {

--- a/rinex/tests/nav.rs
+++ b/rinex/tests/nav.rs
@@ -204,11 +204,93 @@ mod test {
                             "parsed wrong clock data"
                         );
 
-                        assert_eq!(ephemeris.get_orbit_f64("iode"), Some(0.0_f64));
-                        assert_eq!(ephemeris.get_orbit_f64("m0"), Some(-1.673144695710));
-                        assert_eq!(ephemeris.get_orbit_f64("iodc"), Some(-1.117587089540E-8));
-                        assert_eq!(ephemeris.get_orbit_f64("t_tm"), Some(0.000000000000));
-                        assert_eq!(ephemeris.get_orbit_f64("fitInt"), Some(4.283760000000E5));
+                        for (field, data) in vec![
+                            ("iode", Some(0.0_f64)),
+                            ("crs", Some(-1.509375000000E1)),
+                            ("deltaN", Some(5.043781392540E-9)),
+                            ("m0", Some(-1.673144695710)),
+                            ("cuc", Some(-8.475035429000E-7)),
+                            ("e", Some(1.431132073050E-2)),
+                            ("cus", Some(5.507841706280E-6)),
+                            ("sqrta", Some(5.153606595990E3)),
+                            ("toe", Some(4.319840000000E5)),
+                            ("cic", Some(2.216547727580E-7)),
+                            ("omega0", Some(2.333424778860)),
+                            ("cis", Some(-8.009374141690E-8)),
+                            ("i0", Some(9.519533967710E-1)),
+                            ("crc", Some(2.626562500000E2)),
+                            ("omega", Some(-2.356931900380)),
+                            ("omegaDot", Some(-8.034263032640E-9)),
+                            ("idot", Some(-1.592923432050E-10)),
+                            ("l2Codes", Some(1.000000000000)),
+                            ("l2pDataFlag", Some(0.000000000000)),
+                            ("svAccuracy", Some(0.000000000000)),
+                            ("tgd", Some(-1.117587089540E-8)),
+                            ("iodc", Some(0.000000000000)),
+                            ("t_tm", Some(4.283760000000E5)),
+                        ] {
+                            let value = ephemeris.get_orbit_f64(field);
+                            assert!(value.is_some(), "missing orbit filed \"{}\"", field);
+                            assert_eq!(
+                                value, data,
+                                "parsed wrong \"{}\" value, expecting {:?} got {:?}",
+                                field, data, value
+                            );
+                        }
+                        assert!(
+                            ephemeris.get_orbit_f64("fitInt").is_none(),
+                            "parsed fitInt unexpectedly"
+                        );
+
+                        assert_eq!(ephemeris.get_week(), Some(2138));
+                    }
+                } else if *e == Epoch::from_str("2021-01-02T00:00:00").unwrap() {
+                    if sv.prn == 30 {
+                        assert_eq!(
+                            ephemeris.sv_clock(),
+                            (-3.621461801230E-04, -6.139089236970E-12, 0.000000000000),
+                            "parsed wrong clock data"
+                        );
+
+                        for (field, data) in vec![
+                            ("iode", Some(8.500000000000E1)),
+                            ("crs", Some(-7.500000000000)),
+                            ("deltaN", Some(5.476656696160E-9)),
+                            ("m0", Some(-1.649762378650)),
+                            ("cuc", Some(-6.072223186490E-7)),
+                            ("e", Some(4.747916595080E-3)),
+                            ("cus", Some(5.392357707020E-6)),
+                            ("sqrta", Some(5.153756387710E+3)),
+                            ("toe", Some(5.184000000000E+5)),
+                            ("cic", Some(7.636845111850E-8)),
+                            ("omega0", Some(2.352085289360E+00)),
+                            ("cis", Some(-2.421438694000E-8)),
+                            ("i0", Some(9.371909002540E-1)),
+                            ("crc", Some(2.614687500000E+2)),
+                            ("omega", Some(-2.846234079630)),
+                            ("omegaDot", Some(-8.435351366240E-9)),
+                            ("idot", Some(-7.000291590240E-11)),
+                            ("l2Codes", Some(1.000000000000)),
+                            ("l2pDataFlag", Some(0.0)),
+                            ("svAccuracy", Some(0.0)),
+                            ("tgd", Some(3.725290298460E-9)),
+                            ("iodc", Some(8.500000000000E1)),
+                            ("t_tm", Some(5.146680000000E5)),
+                        ] {
+                            let value = ephemeris.get_orbit_f64(field);
+                            assert!(value.is_some(), "missing orbit filed \"{}\"", field);
+                            assert_eq!(
+                                value, data,
+                                "parsed wrong \"{}\" value, expecting {:?} got {:?}",
+                                field, data, value
+                            );
+                        }
+                        assert!(
+                            ephemeris.get_orbit_f64("fitInt").is_none(),
+                            "parsed fitInt unexpectedly"
+                        );
+
+                        assert_eq!(ephemeris.get_week(), Some(2138));
                     }
                 }
             }


### PR DESCRIPTION
Preliminary work to support CNAV, CNAV-2 and other modern Ephemeris frames.

----

Answers 

- [x] #133

preliminary work to provide an answer to 

- #78
- and #80

To fully support NAV-V4, we need a slightly more complex Navigation Frame database, 
because the frames content now depends on `NavMsgType` also.
Therefore, this field needs to be introduced in the database, and taken care of.

This branch only introduces the foundation and we still only truly support `NavMsgType::LNAV` only.  
Modern frames will be introduced in following contributions.

  - Modified (and simplified) the JSON description to describe the `NavMsgType`. 

This modification also impacts the Rinex filter designer, because filtering on Nav Orbit Fields is one possible type of filter.

The `build.rs` script is slightly improved:

  - Don't need to use '&str' fields everywhere! 
We can use Rinex types directly (like `Constellation` or `NavMsgType`).
This saves the `&str` interpretation and cast to these structures, when we actually browse the NAV RINEX standards

  -  Improved the `closest_nav_standards` utility, which browse our DataBase when we need to identify an navigation. It previously returned the closest revision. We still had to actually grab its content. Now we return the entire Frame Description, which makes it easier when parsing.

-  Add more thorough `closest_nav_standards` tests 