### PR TITLE
only rinex-qc and cli need SP3 dependency

### DIFF
--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -47,7 +47,6 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 flate2 = { version = "1.0.24", optional = true, default-features = false, features = ["zlib"] }
 hifitime = { version = "3.8", features = ["serde", "std"] }
 horrorshow = { version = "0.8", optional = true }
-sp3 = { version = "1.0.0", optional = true, features = ["serde", "flate2"] }
 rinex-qc-traits = { path = "../qc-traits", optional = true }
 
 [dev-dependencies]

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -52,6 +52,7 @@ rinex-qc-traits = { path = "../qc-traits", optional = true }
 [dev-dependencies]
 serde_json = "1"
 criterion = "0.5"
+rand = "0.8"
 
 [[bench]]
 name = "benchmark"

--- a/rinex/src/tests/compression.rs
+++ b/rinex/src/tests/compression.rs
@@ -81,8 +81,10 @@ mod test {
             let rnx = rnx.unwrap();
             let compressed = rnx.rnx2crnx1();
 
+            let tmp_path = format!("test-{}.crx", random_name(8));
+
             assert!(
-                compressed.to_file("test.crx").is_ok(),
+                compressed.to_file(&tmp_path).is_ok(),
                 "{}{}",
                 "failed to format compressed rinex",
                 testfile
@@ -98,7 +100,7 @@ mod test {
             );
 
             // remove generated file
-            let _ = std::fs::remove_file("test.crx");
+            let _ = std::fs::remove_file(&tmp_path);
         }
     }
 }

--- a/rinex/src/tests/production.rs
+++ b/rinex/src/tests/production.rs
@@ -1,24 +1,21 @@
 #[cfg(test)]
 mod test {
-    use crate::tests::toolkit::compare_with_panic;
+    use crate::tests::toolkit::{compare_with_panic, random_name};
     use crate::*;
     fn testbench(path: &str) {
         // parse this file
         let rnx = Rinex::from_file(path).unwrap(); // already tested elsewhere
-        let copy_path = path.to_owned() + "-copy";
-        assert_eq!(rnx.to_file(&copy_path).is_ok(), true); // test writer
-        let copy = Rinex::from_file(&copy_path);
+        let tmp_path = format!("test-{}.rnx", random_name(5));
+        assert_eq!(rnx.to_file(&tmp_path).is_ok(), true); // test writer
+        let copy = Rinex::from_file(&tmp_path);
         assert_eq!(copy.is_ok(), true); // content should be valid
         let copy = copy.unwrap();
         // run comparison
         if copy != rnx {
             compare_with_panic(&copy, &rnx, path);
         }
-        // remove copy not to disturb other test browsers
-        let _ = std::fs::remove_file(copy_path);
-        // sleep for a bit
-        // avoids this (temporary) file being picked up by other automated tests
-        // std::thread::sleep(std::time::Duration::from_secs(1));
+        // remove copy
+        let _ = std::fs::remove_file(tmp_path);
     }
     #[test]
     fn obs_v2() {

--- a/rinex/src/tests/toolkit.rs
+++ b/rinex/src/tests/toolkit.rs
@@ -1,4 +1,15 @@
 use crate::*;
+use rand::{distributions::Alphanumeric, Rng};
+/*
+ * Tool to generate random names when we need to produce a file
+ */
+pub fn random_name(size: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .map(char::from)
+        .collect()
+}
 /*
  * OBS RINEX thorough comparison
  */


### PR DESCRIPTION
- [x] Only rinex-qc and rinex-cli need the SP3 library actually. It is no longer needed by the parser,
since we split the QC into a separate library
- [x] Improve general test environment. From time to time, we're facing false negative (false test failures), because tests get executed in a multi threaded environment and we use basic and similar names like "test.crx" or "tmp.rnx" in separate methods.
With this simple random name generator, we make sure each tasklet creates a unique file.  
We also made sure, in a previous contribution, that all temporary generated files get removed at the end of the test execution. 