### PR TITLE
Release 0.13.0

### DIFF
--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinex-cli"
-version = "0.9.0"
+version = "0.9.1"
 license = "MIT OR Apache-2.0"
 authors = ["Guillaume W. Bres <guillaume.bressaix@gmail.com>"]
 description = "Command line tool parse and analyze RINEX data"

--- a/rinex-cli/src/cli.rs
+++ b/rinex-cli/src/cli.rs
@@ -224,15 +224,6 @@ Use --sp3 once per file. You can stack as many as you want."))
                         .action(ArgAction::Append)
                         .help("Local ANTEX file. Enhance given context with ANTEX Data.
 Use --atx once per file to add. You can stack as many as you want."))
-                .next_help_heading("(Precise) Positioning")
-                    .arg(Arg::new("positioning")
-                        .short('p')
-                        .action(ArgAction::SetTrue)
-                        .help("Activate GNSS receiver position solver.
-This is only possible if provided context is sufficient.
-Depending on provided context, either SPP (high accuracy) or PPP (ultra high accuracy)
-method is deployed.
-As this involves quite heavy computations, it is turned off by default."))
                 .next_help_heading("Quality Check (QC)")
                     .arg(Arg::new("qc")
                         .long("qc")
@@ -411,10 +402,6 @@ Refer to README"))
     /// returns true if pretty JSON is requested
     pub fn readable_json(&self) -> bool {
         self.get_flag("readable")
-    }
-    /// Returns true if positioning solver is requested
-    pub fn positioning(&self) -> bool {
-        self.get_flag("positioning")
     }
     /// Returns true if quiet mode is activated
     pub fn quiet(&self) -> bool {

--- a/rinex-cli/src/cli.rs
+++ b/rinex-cli/src/cli.rs
@@ -35,9 +35,8 @@ impl Cli {
                         .long("quiet")
                         .action(ArgAction::SetTrue)
                         .help("Disable all terminal output. Also disables auto HTML reports opener."))
-                    .arg(Arg::new("pretty")
-                        .short('p')
-                        .long("pretty")
+                    .arg(Arg::new("readable")
+                        .short('r')
                         .action(ArgAction::SetTrue)
                         .help("Make terminal output more readable."))
                     .arg(Arg::new("workspace")
@@ -225,6 +224,15 @@ Use --sp3 once per file. You can stack as many as you want."))
                         .action(ArgAction::Append)
                         .help("Local ANTEX file. Enhance given context with ANTEX Data.
 Use --atx once per file to add. You can stack as many as you want."))
+                .next_help_heading("(Precise) Positioning")
+                    .arg(Arg::new("positioning")
+                        .short('p')
+                        .action(ArgAction::SetTrue)
+                        .help("Activate GNSS receiver position solver.
+This is only possible if provided context is sufficient.
+Depending on provided context, either SPP (high accuracy) or PPP (ultra high accuracy)
+method is deployed.
+As this involves quite heavy computations, it is turned off by default."))
                 .next_help_heading("Quality Check (QC)")
                     .arg(Arg::new("qc")
                         .long("qc")
@@ -400,9 +408,13 @@ Refer to README"))
     fn get_flag(&self, flag: &str) -> bool {
         self.matches.get_flag(flag)
     }
-    /// returns true if --pretty was passed
-    pub fn pretty(&self) -> bool {
-        self.get_flag("pretty")
+    /// returns true if pretty JSON is requested
+    pub fn readable_json(&self) -> bool {
+        self.get_flag("readable")
+    }
+    /// Returns true if positioning solver is requested
+    pub fn positioning(&self) -> bool {
+        self.get_flag("positioning")
     }
     /// Returns true if quiet mode is activated
     pub fn quiet(&self) -> bool {

--- a/rinex-cli/src/identification.rs
+++ b/rinex-cli/src/identification.rs
@@ -6,7 +6,7 @@ use rinex_qc::QcContext;
  * Basic identification operations
  */
 pub fn rinex_identification(ctx: &QcContext, cli: &Cli) {
-    let pretty = cli.pretty();
+    let pretty = cli.readable_json();
     let ops = cli.identification_ops();
 
     identification(&ctx.primary_data(), pretty, ops.clone());

--- a/rinex-cli/src/main.rs
+++ b/rinex-cli/src/main.rs
@@ -11,9 +11,6 @@ mod plot; // plotting operations
 mod preprocessing;
 use preprocessing::preprocess;
 
-mod solver;
-use solver::Solver;
-
 //use horrorshow::Template;
 use rinex::{
     merge::Merge,
@@ -205,8 +202,6 @@ pub fn main() -> Result<(), rinex::Error> {
     // Build file context
     let mut ctx = create_context(&cli);
 
-    let mut solver = Solver::from(&ctx);
-
     // Workspace
     let workspace = workspace_path(&ctx);
     info!("workspace is \"{}\"", workspace.to_string_lossy());
@@ -226,20 +221,6 @@ pub fn main() -> Result<(), rinex::Error> {
         info!("using reference position {}", pos);
     } else {
         info!("no reference position given or identified");
-    }
-    /*
-     * print more info on possible solver to deploy
-     */
-    if let Ok(solver) = solver {
-        info!(
-            "provided context is compatible with {} position solver",
-            solver.solver
-        );
-        if !cli.positioning() {
-            warn!("position solver currently turned off");
-        }
-    } else {
-        info!("context is not sufficient for any position solving method");
     }
 
     /*

--- a/rinex-cli/src/main.rs
+++ b/rinex-cli/src/main.rs
@@ -11,6 +11,9 @@ mod plot; // plotting operations
 mod preprocessing;
 use preprocessing::preprocess;
 
+mod solver;
+use solver::Solver;
+
 //use horrorshow::Template;
 use rinex::{
     merge::Merge,
@@ -202,6 +205,8 @@ pub fn main() -> Result<(), rinex::Error> {
     // Build file context
     let mut ctx = create_context(&cli);
 
+    let mut solver = Solver::from(&ctx);
+
     // Workspace
     let workspace = workspace_path(&ctx);
     info!("workspace is \"{}\"", workspace.to_string_lossy());
@@ -221,6 +226,20 @@ pub fn main() -> Result<(), rinex::Error> {
         info!("using reference position {}", pos);
     } else {
         info!("no reference position given or identified");
+    }
+    /*
+     * print more info on possible solver to deploy
+     */
+    if let Ok(solver) = solver {
+        info!(
+            "provided context is compatible with {} position solver",
+            solver.solver
+        );
+        if !cli.positioning() {
+            warn!("position solver currently turned off");
+        }
+    } else {
+        info!("context is not sufficient for any position solving method");
     }
 
     /*

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinex"
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT OR Apache-2.0"
 authors = ["Guillaume W. Bres <guillaume.bressaix@gmail.com>"]
 description = "Package to parse and analyze RINEX data"

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -47,7 +47,6 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 flate2 = { version = "1.0.24", optional = true, default-features = false, features = ["zlib"] }
 hifitime = { version = "3.8", features = ["serde", "std"] }
 horrorshow = { version = "0.8", optional = true }
-sp3 = { version = "1.0.0", optional = true, features = ["serde", "flate2"] }
 rinex-qc-traits = { path = "../qc-traits", optional = true }
 
 [dev-dependencies]

--- a/rinex/src/algorithm/filters/mask.rs
+++ b/rinex/src/algorithm/filters/mask.rs
@@ -222,12 +222,10 @@ impl std::str::FromStr for MaskFilter {
                     operand_offset = Some(i);
                     break;
                 }
-            } else {
-                if let Ok(op) = MaskOperand::from_str(&cleanedup[i..i + 1]) {
-                    operand = Some(op.clone());
-                    operand_offset = Some(i);
-                    break;
-                }
+            } else if let Ok(op) = MaskOperand::from_str(&cleanedup[i..i + 1]) {
+                operand = Some(op.clone());
+                operand_offset = Some(i);
+                break;
             }
         }
 

--- a/rinex/src/algorithm/target.rs
+++ b/rinex/src/algorithm/target.rs
@@ -26,16 +26,16 @@ pub enum Error {
     InvalidSNRDescription,
     #[error("failed to parse sv")]
     SvParingError(#[from] sv::Error),
-    #[error("failed to parse constellation")]
-    ConstellationParingError(#[from] constellation::Error),
+    #[error("constellation parsing error")]
+    ConstellationParing(#[from] constellation::ParsingError),
     #[error("failed to parse epoch flag")]
     EpochFlagParsingError(#[from] crate::epoch::flag::Error),
     #[error("failed to parse constellation")]
     ConstellationParsingError,
     #[error("invalid nav item")]
     InvalidNavItem(#[from] crate::navigation::Error),
-    #[error("invalid observable item")]
-    InvalidObsItem(#[from] crate::observable::Error),
+    #[error("observable parsing error")]
+    ObservableParsing(#[from] observable::ParsingError),
     #[error("invalid duration description")]
     InvalidDurationItem(#[from] hifitime::Errors),
 }
@@ -158,7 +158,7 @@ pub(crate) fn parse_sv_list(items: Vec<&str>) -> Result<Vec<Sv>, sv::Error> {
 
 pub(crate) fn parse_gnss_list(
     items: Vec<&str>,
-) -> Result<Vec<Constellation>, constellation::Error> {
+) -> Result<Vec<Constellation>, constellation::ParsingError> {
     let mut ret: Vec<Constellation> = Vec::with_capacity(items.len());
     for item in items {
         let c = Constellation::from_str(item.trim())?;
@@ -167,7 +167,9 @@ pub(crate) fn parse_gnss_list(
     Ok(ret)
 }
 
-pub(crate) fn parse_obs_list(items: Vec<&str>) -> Result<Vec<Observable>, observable::Error> {
+pub(crate) fn parse_obs_list(
+    items: Vec<&str>,
+) -> Result<Vec<Observable>, observable::ParsingError> {
     let mut ret: Vec<Observable> = Vec::with_capacity(items.len());
     for item in items {
         let obs = Observable::from_str(item.trim())?;

--- a/rinex/src/algorithm/target.rs
+++ b/rinex/src/algorithm/target.rs
@@ -24,8 +24,8 @@ pub enum Error {
     InvalidAzimuthAngleDescription,
     #[error("bad snr description")]
     InvalidSNRDescription,
-    #[error("failed to parse sv")]
-    SvParingError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParing(#[from] sv::ParsingError),
     #[error("constellation parsing error")]
     ConstellationParing(#[from] constellation::ParsingError),
     #[error("failed to parse epoch flag")]
@@ -147,7 +147,7 @@ impl std::ops::BitOr for TargetItem {
     }
 }
 
-pub(crate) fn parse_sv_list(items: Vec<&str>) -> Result<Vec<Sv>, sv::Error> {
+pub(crate) fn parse_sv_list(items: Vec<&str>) -> Result<Vec<Sv>, sv::ParsingError> {
     let mut ret: Vec<Sv> = Vec::with_capacity(items.len());
     for item in items {
         let sv = Sv::from_str(item.trim())?;

--- a/rinex/src/carrier.rs
+++ b/rinex/src/carrier.rs
@@ -75,8 +75,8 @@ pub enum Error {
     ParseError(String),
     //#[error("unable to identify glonass channel from \"{0}\"")]
     //ParseIntError(#[from] std::num::ParseIntError),
-    #[error("unable to identify constellation + carrier code")]
-    SvError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParsing(#[from] sv::ParsingError),
     #[error("carrier::from_observable unrecognized \"{0}\"")]
     UnknownObservable(String),
 }

--- a/rinex/src/clocks/record.rs
+++ b/rinex/src/clocks/record.rs
@@ -152,10 +152,7 @@ pub(crate) fn parse_epoch(
     let (dtype, rem) = line.split_at(3);
     let data_type = DataType::from_str(dtype.trim())?; // must pass
     let mut rem = rem.clone();
-    let limit = Version {
-        major: 3,
-        minor: 04,
-    };
+    let limit = Version { major: 3, minor: 4 };
 
     let system: System = match version < limit {
         true => {

--- a/rinex/src/constellation/mod.rs
+++ b/rinex/src/constellation/mod.rs
@@ -12,19 +12,22 @@ pub use augmentation::sbas_selection_helper;
 
 /// Constellation parsing & identification related errors
 #[derive(Error, Clone, Debug, PartialEq)]
-pub enum Error {
-    #[error("code length mismatch, expecting {0} got {1}")]
-    CodeLengthMismatch(usize, usize),
-    #[error("unknown constellation code \"{0}\"")]
-    UnknownCode(String),
+pub enum ParsingError {
+    #[error("unknown constellation \"{0}\"")]
+    Unknown(String),
+    #[error("unrecognized constellation \"{0}\"")]
+    Unrecognized(String),
+    #[error("unknown constellation format \"{0}\"")]
+    Format(String),
 }
 
 /// Describes all known `GNSS` constellations
 /// when manipulating `RINEX`
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Constellation {
     /// `GPS` american constellation,
+    #[default]
     GPS,
     /// `Glonass` russian constellation
     Glonass,
@@ -53,138 +56,140 @@ impl std::fmt::Display for Constellation {
     }
 }
 
-impl Default for Constellation {
-    /// Builds a default `GNSS::GPS` constellation
-    fn default() -> Constellation {
-        Constellation::GPS
-    }
-}
-
 impl Constellation {
-    /// Identifies `gnss` constellation from given 1 letter code.    
-    /// Given code should match official RINEX codes.    
-    /// This method is case insensitive though
-    pub fn from_1_letter_code(code: &str) -> Result<Constellation, Error> {
+    /*
+     * Identifies GNSS constellation from standard 1 letter code
+     * but can insensitive.
+     * Mostly used in Self::from_str (public method)
+     */
+    pub(crate) fn from_1_letter_code(code: &str) -> Result<Self, ParsingError> {
         if code.len() != 1 {
-            return Err(Error::CodeLengthMismatch(1, code.len()));
+            return Err(ParsingError::Format(code.to_string()));
         }
-        if code.to_lowercase().eq("g") {
-            Ok(Constellation::GPS)
-        } else if code.to_lowercase().eq("r") {
-            Ok(Constellation::Glonass)
-        } else if code.to_lowercase().eq("c") {
-            Ok(Constellation::BeiDou)
-        } else if code.to_lowercase().eq("e") {
-            Ok(Constellation::Galileo)
-        } else if code.to_lowercase().eq("j") {
-            Ok(Constellation::QZSS)
-        } else if code.to_lowercase().eq("s") {
-            Ok(Constellation::Geo)
-        } else if code.to_lowercase().eq("i") {
-            Ok(Constellation::IRNSS)
-        } else if code.to_lowercase().eq("m") {
-            Ok(Constellation::Mixed)
+
+        let lower = code.to_lowercase();
+        if lower.eq("g") {
+            Ok(Self::GPS)
+        } else if lower.eq("r") {
+            Ok(Self::Glonass)
+        } else if lower.eq("c") {
+            Ok(Self::BeiDou)
+        } else if lower.eq("e") {
+            Ok(Self::Galileo)
+        } else if lower.eq("j") {
+            Ok(Self::QZSS)
+        } else if lower.eq("s") {
+            Ok(Self::Geo)
+        } else if lower.eq("i") {
+            Ok(Self::IRNSS)
+        } else if lower.eq("m") {
+            Ok(Self::Mixed)
         } else {
-            Err(Error::UnknownCode(code.to_string()))
+            Err(ParsingError::Unknown(code.to_string()))
+        }
+    }
+    /*
+     * Identifies Constellation from stanadrd 3 letter code, case insensitive.
+     * Used in public Self::from_str, or some place else in that crate.
+     */
+    pub(crate) fn from_3_letter_code(code: &str) -> Result<Self, ParsingError> {
+        if code.len() != 3 {
+            return Err(ParsingError::Format(code.to_string()));
+        }
+
+        let lower = code.to_lowercase();
+        if lower.eq("gps") {
+            Ok(Self::GPS)
+        } else if lower.eq("glo") {
+            Ok(Self::Glonass)
+        } else if lower.eq("bds") {
+            Ok(Self::BeiDou)
+        } else if lower.eq("gal") {
+            Ok(Self::Galileo)
+        } else if lower.eq("qzs") {
+            Ok(Self::QZSS)
+        } else if lower.eq("sbs") | lower.eq("geo") {
+            Ok(Self::Geo)
+        } else if lower.eq("irn") {
+            Ok(Self::IRNSS)
+        } else {
+            Err(ParsingError::Unknown(code.to_string()))
+        }
+    }
+    /*
+     * Identifies `gnss` constellation from given standard plain name,
+     * like "GPS", or "Galileo". This method is not case sensitive.
+     * Used in public Self::from_str, or some place else in that crate.
+     */
+    pub(crate) fn from_plain_name(code: &str) -> Result<Constellation, ParsingError> {
+        let lower = code.to_lowercase();
+        if lower.contains("gps") {
+            Ok(Self::GPS)
+        } else if lower.contains("glonass") {
+            Ok(Self::Glonass)
+        } else if lower.contains("galileo") {
+            Ok(Self::Galileo)
+        } else if lower.contains("qzss") {
+            Ok(Self::QZSS)
+        } else if lower.contains("beidou") {
+            Ok(Self::BeiDou)
+        } else if lower.contains("sbas") {
+            Ok(Self::Geo)
+        } else if lower.contains("geo") {
+            Ok(Self::Geo)
+        } else if lower.contains("irnss") {
+            Ok(Self::IRNSS)
+        } else if lower.contains("mixed") {
+            Ok(Self::Mixed)
+        } else {
+            Err(ParsingError::Unrecognized(code.to_string()))
         }
     }
     /// Converts self to 1 letter code (RINEX standard code)
     pub fn to_1_letter_code(&self) -> &str {
         match self {
-            Constellation::GPS => "G",
-            Constellation::Glonass => "R",
-            Constellation::Galileo => "E",
-            Constellation::BeiDou => "C",
-            Constellation::SBAS(_) | Constellation::Geo => "S",
-            Constellation::QZSS => "J",
-            Constellation::IRNSS => "I",
-            Constellation::Mixed => "M",
-        }
-    }
-    /// Identifies `gnss` constellation from given 3 letter code.    
-    /// Given code should match official RINEX codes.    
-    /// This method is case insensitive though
-    pub(crate) fn from_3_letter_code(code: &str) -> Result<Constellation, Error> {
-        if code.len() != 3 {
-            return Err(Error::CodeLengthMismatch(3, code.len()));
-        }
-        let code = code.to_lowercase();
-        if code.eq("gps") {
-            Ok(Constellation::GPS)
-        } else if code.eq("glo") {
-            Ok(Constellation::Glonass)
-        } else if code.eq("bds") {
-            Ok(Constellation::BeiDou)
-        } else if code.eq("gal") {
-            Ok(Constellation::Galileo)
-        } else if code.eq("qzs") {
-            Ok(Constellation::QZSS)
-        } else if code.eq("sbs") | code.eq("geo") {
-            Ok(Constellation::Geo)
-        } else if code.eq("irn") {
-            Ok(Constellation::IRNSS)
-        } else {
-            Err(Error::UnknownCode(code.to_string()))
+            Self::GPS => "G",
+            Self::Glonass => "R",
+            Self::Galileo => "E",
+            Self::BeiDou => "C",
+            Self::SBAS(_) | Self::Geo => "S",
+            Self::QZSS => "J",
+            Self::IRNSS => "I",
+            Self::Mixed => "M",
         }
     }
     /// Converts self to 3 letter code (RINEX standard code)
     pub(crate) fn to_3_letter_code(&self) -> &str {
         match self {
-            Constellation::GPS => "GPS",
-            Constellation::Glonass => "GLO",
-            Constellation::Galileo => "GAL",
-            Constellation::BeiDou => "BDS",
-            Constellation::SBAS(_) | Constellation::Geo => "GEO",
-            Constellation::QZSS => "QZS",
-            Constellation::IRNSS => "IRN",
-            Constellation::Mixed => "MIX",
-        }
-    }
-    /// Identifies `gnss` constellation from given standard plain name,
-    /// like "GPS", or "Galileo". This method is not case sensitive.
-    pub(crate) fn from_plain_name(code: &str) -> Result<Constellation, Error> {
-        let code = code.to_lowercase();
-        if code.contains("gps") {
-            Ok(Constellation::GPS)
-        } else if code.contains("glonass") {
-            Ok(Constellation::Glonass)
-        } else if code.contains("galileo") {
-            Ok(Constellation::Galileo)
-        } else if code.contains("qzss") {
-            Ok(Constellation::QZSS)
-        } else if code.contains("beidou") {
-            Ok(Constellation::BeiDou)
-        } else if code.contains("sbas") {
-            Ok(Constellation::Geo)
-        } else if code.contains("geo") {
-            Ok(Constellation::Geo)
-        } else if code.contains("irnss") {
-            Ok(Constellation::IRNSS)
-        } else if code.contains("mixed") {
-            Ok(Constellation::Mixed)
-        } else {
-            Err(Error::UnknownCode(code.to_string()))
+            Self::GPS => "GPS",
+            Self::Glonass => "GLO",
+            Self::Galileo => "GAL",
+            Self::BeiDou => "BDS",
+            Self::SBAS(_) | Self::Geo => "GEO",
+            Self::QZSS => "QZS",
+            Self::IRNSS => "IRN",
+            Self::Mixed => "MIX",
         }
     }
 }
 
 impl std::str::FromStr for Constellation {
-    type Err = Error;
+    type Err = ParsingError;
     /// Identifies `gnss` constellation from given code.   
     /// Code should be standard constellation name,
     /// or official 1/3 letter RINEX code.    
     /// This method is case insensitive
     fn from_str(code: &str) -> Result<Self, Self::Err> {
         if code.len() == 3 {
-            Ok(Constellation::from_3_letter_code(code)?)
+            Ok(Self::from_3_letter_code(code)?)
         } else if code.len() == 1 {
-            Ok(Constellation::from_1_letter_code(code)?)
-        } else if let Ok(s) = Constellation::from_plain_name(code) {
+            Ok(Self::from_1_letter_code(code)?)
+        } else if let Ok(s) = Self::from_plain_name(code) {
             Ok(s)
         } else if let Ok(sbas) = Augmentation::from_str(code) {
             Ok(Self::SBAS(sbas))
         } else {
-            Err(Error::UnknownCode(code.to_string()))
+            Err(ParsingError::Unknown(code.to_string()))
         }
     }
 }

--- a/rinex/src/epoch/mod.rs
+++ b/rinex/src/epoch/mod.rs
@@ -127,10 +127,8 @@ pub(crate) fn format(epoch: Epoch, flag: Option<EpochFlag>, t: Type, revision: u
  */
 pub(crate) fn parse(s: &str) -> Result<(Epoch, EpochFlag), Error> {
     let items: Vec<&str> = s.split_ascii_whitespace().collect();
-    if items.len() != 6 {
-        if items.len() != 7 {
-            return Err(Error::FormatError);
-        }
+    if items.len() != 6 && items.len() != 7 {
+        return Err(Error::FormatError);
     }
     if let Ok(mut y) = i32::from_str_radix(items[0], 10) {
         if y < 100 {

--- a/rinex/src/hatanaka/mod.rs
+++ b/rinex/src/hatanaka/mod.rs
@@ -40,8 +40,8 @@ pub enum Error {
     MalformedEpochBody,
     #[error("numdiff error")]
     NumDiffError(#[from] numdiff::Error),
-    #[error("failed to identify sat. vehicle")]
-    SvError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParsing(#[from] sv::ParsingError),
     #[error("failed to parse integer number")]
     ParseIntError(#[from] std::num::ParseIntError),
 }

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -604,7 +604,7 @@ impl Header {
                         .or(Err(parse_int_error!("SYS / SCALE FACTOR", factor)))?;
 
                     let (_num, rem) = rem.split_at(3);
-                    
+
                     // parse end of line
                     let mut len = rem.len();
                     let mut rem = rem.clone();
@@ -620,7 +620,6 @@ impl Header {
                     }
                     scaling_count += 1;
                 }
-
             } else if marker.contains("SENSOR MOD/TYPE/ACC") {
                 if let Ok(sensor) = meteo::sensor::Sensor::from_str(content) {
                     meteo.sensors.push(sensor)

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -21,11 +21,12 @@ use thiserror::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, EnumString)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, EnumString)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MarkerType {
     /// Earth fixed & high precision
     #[strum(serialize = "GEODETIC", serialize = "Geodetic")]
+    #[default]
     Geodetic,
     /// Earth fixed & low precision
     #[strum(serialize = "NON GEODETIC", serialize = "NonGeodetic")]
@@ -66,12 +67,6 @@ pub enum MarkerType {
     /// Human being carrying a receiver
     #[strum(serialize = "HUMAN", serialize = "Human")]
     Human,
-}
-
-impl Default for MarkerType {
-    fn default() -> Self {
-        Self::Geodetic
-    }
 }
 
 /// DCB compensation description

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -174,8 +174,6 @@ pub struct Header {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("CRINEX related content mismatch")]
-    CrinexFormatError,
     #[error("RINEX version is not supported '{0}'")]
     VersionNotSupported(String),
     #[error("Line \"{0}\" should begin with Rinex version \"x.yy\"")]

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -208,7 +208,7 @@ pub enum ParsingError {
     IonexGridError(#[from] ionex::grid::Error),
     #[error("invalid crinex header \"{0}\": \"{1}\"")]
     CrinexHeader(String, String),
-    #[error("failed to parse datetime {} field from \"{1}\"")]
+    #[error("failed to parse datetime {0} field from \"{1}\"")]
     DateTimeParsing(String, String),
 }
 

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -508,7 +508,7 @@ impl Header {
                 let (y, rem) = rem.split_at(14);
                 let (z, rem) = rem.split_at(14);
                 let (h, phys) = rem.split_at(14);
-                
+
                 let phys = phys.trim();
                 let observable = Observable::from_str(phys)?;
 

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -508,20 +508,37 @@ impl Header {
                 let (y, rem) = rem.split_at(14);
                 let (z, rem) = rem.split_at(14);
                 let (h, phys) = rem.split_at(14);
+                
                 let phys = phys.trim();
                 let observable = Observable::from_str(phys)?;
 
+                let x = x.trim();
+                let x = f64::from_str(x).or(Err(ParsingError::CoordinatesParsing(
+                    String::from("SENSOR POS X"),
+                    x.to_string(),
+                )))?;
+
+                let y = y.trim();
+                let y = f64::from_str(y).or(Err(ParsingError::CoordinatesParsing(
+                    String::from("SENSOR POS Y"),
+                    y.to_string(),
+                )))?;
+
+                let z = z.trim();
+                let z = f64::from_str(z).or(Err(ParsingError::CoordinatesParsing(
+                    String::from("SENSOR POS Z"),
+                    z.to_string(),
+                )))?;
+
+                let h = h.trim();
+                let h = f64::from_str(h).or(Err(ParsingError::CoordinatesParsing(
+                    String::from("SENSOR POS H"),
+                    h.to_string(),
+                )))?;
+
                 for sensor in meteo.sensors.iter_mut() {
                     if sensor.observable == observable {
-                        if let Ok(x) = f64::from_str(x.trim()) {
-                            if let Ok(y) = f64::from_str(y.trim()) {
-                                if let Ok(z) = f64::from_str(z.trim()) {
-                                    if let Ok(h) = f64::from_str(h.trim()) {
-                                        *sensor = sensor.with_position((x, y, z, h))
-                                    }
-                                }
-                            }
-                        }
+                        *sensor = sensor.with_position((x, y, z, h))
                     }
                 }
             } else if marker.contains("LEAP SECOND") {

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -8,7 +8,7 @@ use crate::{
     ionex, leap, meteo, observation,
     observation::Crinex,
     reader::BufferedReader,
-    types::{Type, TypeError},
+    types::Type,
     version::Version,
     Observable,
 };
@@ -178,10 +178,10 @@ pub enum ParsingError {
     VersionNotSupported(String),
     #[error("failed to parse version from \"{0}\"")]
     VersionParsing(String),
-    #[error("Line \"{0}\" should begin with Rinex version \"x.yy\"")]
+    #[error("unknown RINEX type \"{0}\"")]
+    TypeParsing(String),
+    #[error("line \"{0}\" should begin with Rinex version \"x.yy\"")]
     VersionFormatError(String),
-    #[error("rinex type error")]
-    TypeError(#[from] TypeError),
     #[error("constellation error")]
     ConstellationError(#[from] constellation::Error),
     #[error("failed to parse leap from \"{0}\"")]

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -292,7 +292,7 @@ impl Header {
         let mut ground_position: Option<GroundPosition> = None;
         let mut dcb_compensations: Vec<DcbCompensation> = Vec::new();
         let mut pcv_compensations: Vec<PcvCompensation> = Vec::new();
-        let mut scaling_count = 0_16;
+        let mut scaling_count = 0_u16;
         // RINEX specific fields
         let mut current_constell: Option<Constellation> = None;
         let mut observation = observation::HeaderFields::default();
@@ -1084,7 +1084,7 @@ impl Header {
         }
 
         Ok(Header {
-            version: version,
+            version,
             rinex_type,
             constellation,
             comments,

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -18,26 +18,6 @@ use std::str::FromStr;
 use strum_macros::EnumString;
 use thiserror::Error;
 
-macro_rules! from_b_fmt_month {
-    ($m: expr) => {
-        match $m {
-            "Jan" => 1,
-            "Feb" => 2,
-            "Mar" => 3,
-            "Apr" => 4,
-            "May" => 5,
-            "Jun" => 6,
-            "Jul" => 7,
-            "Aug" => 8,
-            "Sep" => 9,
-            "Oct" => 10,
-            "Nov" => 11,
-            "Dec" => 12,
-            _ => 1,
-        }
-    };
-}
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -212,6 +192,24 @@ pub enum ParsingError {
     DateTimeParsing(String, String),
 }
 
+fn parse_formatted_month(content: &str) -> Result<u8, ParsingError> {
+    match content {
+        "Jan" => Ok(1),
+        "Feb" => Ok(2),
+        "Mar" => Ok(3),
+        "Apr" => Ok(4),
+        "May" => Ok(5),
+        "Jun" => Ok(6),
+        "Jul" => Ok(7),
+        "Aug" => Ok(8),
+        "Sep" => Ok(9),
+        "Oct" => Ok(10),
+        "Nov" => Ok(11),
+        "Dec" => Ok(12),
+        _ => Err(ParsingError::DateTimeParsing(String::from("month"), content.to_string())),
+    }
+}
+
 impl Default for Header {
     fn default() -> Header {
         Header {
@@ -338,7 +336,7 @@ impl Header {
                 )))?;
 
                 let month = date[1].trim();
-                let month = from_b_fmt_month!(month);
+                let month = parse_formatted_month(month)?;
 
                 let y = date[2].trim();
                 let mut y = i32::from_str_radix(y, 10).or(Err(ParsingError::DateTimeParsing(
@@ -1980,12 +1978,14 @@ impl HtmlReport for Header {
 
 #[cfg(test)]
 mod test {
+    use super::parse_formatted_month;
     #[test]
-    fn test_from_b_fmt_month() {
-        assert_eq!(from_b_fmt_month!("Jan"), 1);
-        assert_eq!(from_b_fmt_month!("Feb"), 2);
-        assert_eq!(from_b_fmt_month!("Mar"), 3);
-        assert_eq!(from_b_fmt_month!("Nov"), 11);
-        assert_eq!(from_b_fmt_month!("Dec"), 12);
+    fn formatted_month_parser() {
+        for (desc, expected) in vec![("Jan", 1), ("Feb", 2), ("Mar", 3), ("Nov", 11), ("Dec", 12)] {
+            let month = parse_formatted_month(desc);
+            assert!(month.is_ok(), "failed to parse month from \"{}\"", desc);
+            let month = month.unwrap();
+            assert_eq!(month, expected, "failed to parse correct month number from \"{}\"", desc);
+        }
     }
 }

--- a/rinex/src/ionex/record.rs
+++ b/rinex/src/ionex/record.rs
@@ -197,10 +197,10 @@ pub(crate) fn parse_map(header: &mut Header, content: &str) -> Result<(usize, Ep
                         let mut value = v as f64;
                         value *= 10.0_f64.powf(ionex.exponent as f64);
                         map.push(MapPoint {
-                            latitude: latitude,
+                            latitude,
                             longitude: linspace.start + linspace.spacing * ptr as f64,
-                            altitude: altitude,
-                            value: value,
+                            altitude,
+                            value,
                         });
                         ptr += 1;
                     }
@@ -215,10 +215,10 @@ pub(crate) fn parse_map(header: &mut Header, content: &str) -> Result<(usize, Ep
                     let mut value = v as f64;
                     value *= 10.0_f64.powf(ionex.exponent as f64);
                     map.push(MapPoint {
-                        latitude: latitude,
+                        latitude,
                         longitude: linspace.start + linspace.spacing * ptr as f64,
-                        altitude: altitude,
-                        value: value,
+                        altitude,
+                        value,
                     });
                     ptr += 1;
                 }

--- a/rinex/src/ionex/system.rs
+++ b/rinex/src/ionex/system.rs
@@ -99,20 +99,14 @@ impl FromStr for RefSystem {
     fn from_str(system: &str) -> Result<Self, Self::Err> {
         if let Ok(gnss) = Constellation::from_str(system) {
             Ok(Self::GnssConstellation(gnss))
+        } else if system.eq("GNSS") {
+            Ok(Self::GnssConstellation(Constellation::Mixed))
+        } else if let Ok(obs) = ObsSystem::from_str(system) {
+            Ok(Self::ObservationSystem(obs))
+        } else if let Ok(m) = Model::from_str(system) {
+            Ok(Self::Model(m))
         } else {
-            if system.eq("GNSS") {
-                Ok(Self::GnssConstellation(Constellation::Mixed))
-            } else {
-                if let Ok(obs) = ObsSystem::from_str(system) {
-                    Ok(Self::ObservationSystem(obs))
-                } else {
-                    if let Ok(m) = Model::from_str(system) {
-                        Ok(Self::Model(m))
-                    } else {
-                        Err(Error::UnknownRefSystem)
-                    }
-                }
-            }
+            Err(Error::UnknownRefSystem)
         }
     }
 }

--- a/rinex/src/ionex/system.rs
+++ b/rinex/src/ionex/system.rs
@@ -6,10 +6,10 @@ use thiserror::Error;
 /// Reference System parsing error
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("unknown gnss constellation")]
-    ConstellationError(#[from] constellation::Error),
     #[error("unknown reference system")]
     UnknownRefSystem,
+    #[error("constellation parsing error")]
+    ConstellationParsing(#[from] constellation::ParsingError),
 }
 
 /// RefSystem "Reference System" describes either reference GNSS

--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -191,7 +191,7 @@ pub struct Rinex {
 /// `RINEX` Parsing related errors
 pub enum Error {
     #[error("header parsing error")]
-    HeaderError(#[from] header::Error),
+    HeaderParsingError(#[from] header::ParsingError),
     #[error("record parsing error")]
     RecordError(#[from] record::Error),
     #[error("file i/o error")]

--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -227,7 +227,7 @@ impl Rinex {
         Rinex {
             header: self.header.clone(),
             comments: self.comments.clone(),
-            record: record,
+            record,
         }
     }
 
@@ -1229,9 +1229,9 @@ impl Rinex {
                         false
                     }
                 });
-                systems.len() > 0
+                !systems.is_empty()
             });
-            dtypes.len() > 0
+            !dtypes.is_empty()
         })
     }
     /// Writes self into given file.   
@@ -1586,7 +1586,7 @@ impl Rinex {
             Box::new(
                 // grab all vehicles identified through all Epochs
                 // and fold them into individual lists
-                record.into_iter().map(|((epoch, _), (_clk, entries))| {
+                record.iter().map(|((epoch, _), (_clk, entries))| {
                     (*epoch, entries.keys().unique().cloned().collect())
                 }),
             )
@@ -1594,7 +1594,7 @@ impl Rinex {
             Box::new(
                 // grab all vehicles through all epochs,
                 // fold them into individual lists
-                record.into_iter().map(|(epoch, frames)| {
+                record.iter().map(|(epoch, frames)| {
                     (
                         *epoch,
                         frames

--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -1947,7 +1947,9 @@ impl Rinex {
                         if let Some(header) = &self.header.obs {
                             // apply a scaling, if any, otherwise : leave data untouched
                             // to preserve its precision
-                            if let Some(scaling) = header.scaling(&sv.constellation, observable) {
+                            if let Some(scaling) =
+                                header.scaling(sv.constellation, observable.clone())
+                            {
                                 Some((*e, *sv, observable, obsdata.obs / *scaling as f64))
                             } else {
                                 Some((*e, *sv, observable, obsdata.obs))

--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -1948,7 +1948,7 @@ impl Rinex {
                             // apply a scaling, if any, otherwise : leave data untouched
                             // to preserve its precision
                             if let Some(scaling) = header.scaling(&sv.constellation, observable) {
-                                Some((*e, *sv, observable, obsdata.obs / scaling))
+                                Some((*e, *sv, observable, obsdata.obs / *scaling as f64))
                             } else {
                                 Some((*e, *sv, observable, obsdata.obs))
                             }

--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -347,7 +347,6 @@ impl Rinex {
                     crinex: None,
                     codes: params.codes.clone(),
                     clock_offset_applied: params.clock_offset_applied,
-                    dcb_compensations: params.dcb_compensations.clone(),
                     scalings: params.scalings.clone(),
                 });
         }
@@ -616,17 +615,24 @@ impl Rinex {
     /// In very high precision and specific applications, you then do not have
     /// to deal with their compensation yourself.
     pub fn dcb_compensation(&self, constellation: Constellation) -> bool {
-        if let Some(obs) = &self.header.obs {
-            obs.dcb_compensations
-                .iter()
-                .filter(|dcb| dcb.constellation == constellation)
-                .count()
-                > 0
-        } else {
-            false
-        }
+        self.header
+            .dcb_compensations
+            .iter()
+            .filter(|dcb| dcb.constellation == constellation)
+            .count()
+            > 0
     }
 
+    /// Returns true if Antenna Phase Center variations are compensated
+    /// for in this file. Useful for high precision application.
+    pub fn pcv_compensation(&self, constellation: Constellation) -> bool {
+        self.header
+            .pcv_compensations
+            .iter()
+            .filter(|pcv| pcv.constellation == constellation)
+            .count()
+            > 0
+    }
     /// Returns `true` if self is a `merged` RINEX file,   
     /// meaning, this file is the combination of two RINEX files merged together.  
     /// This is determined by the presence of a custom yet somewhat standardized `FILE MERGE` comments

--- a/rinex/src/merge.rs
+++ b/rinex/src/merge.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// Merge operation related error(s)
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("file type mismatch: cannot merge different types together")]
+    #[error("file type mismatch: cannot merge different RINEX together")]
     FileTypeMismatch,
     #[error("cannot merge mixed absolute/relative phase antenna together")]
     AntexAbsoluteRelativeMismatch,

--- a/rinex/src/meteo/sensor.rs
+++ b/rinex/src/meteo/sensor.rs
@@ -22,8 +22,8 @@ pub struct Sensor {
 
 #[derive(Error, Debug)]
 pub enum ParseSensorError {
-    #[error("failed to identify observable")]
-    ParseObservableError(#[from] observable::Error),
+    #[error("observable parsing error")]
+    ObservableParsingErro(#[from] observable::ParsingError),
     #[error("failed to parse accuracy field")]
     ParseFloatError(#[from] std::num::ParseFloatError),
 }

--- a/rinex/src/navigation/ephemeris.rs
+++ b/rinex/src/navigation/ephemeris.rs
@@ -19,8 +19,8 @@ pub enum Error {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("failed to parse epoch")]
     EpochError(#[from] epoch::Error),
-    #[error("failed to identify sat vehicle")]
-    ParseSvError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParsing(#[from] sv::ParsingError),
 }
 
 /// Ephermeris NAV frame type

--- a/rinex/src/navigation/mod.rs
+++ b/rinex/src/navigation/mod.rs
@@ -32,8 +32,8 @@ pub enum Error {
     UnknownFrameClass,
     #[error("unknown nav message type")]
     UnknownNavMsgType,
-    #[error("failed to parse msg type")]
-    SvError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParsing(#[from] sv::ParsingError),
     #[error("failed to parse orbit field")]
     ParseOrbitError(#[from] orbits::OrbitItemError),
     #[error("failed to parse sv::prn")]

--- a/rinex/src/navigation/record.rs
+++ b/rinex/src/navigation/record.rs
@@ -1370,7 +1370,7 @@ fn mask_mut_ineq(rec: &mut Record, target: TargetItem) {
                         false
                     }
                 });
-                frames.len() > 0
+                !frames.is_empty()
             });
         },
         TargetItem::NavMsgItem(filter) => {
@@ -1388,7 +1388,7 @@ fn mask_mut_ineq(rec: &mut Record, target: TargetItem) {
                         false
                     }
                 });
-                frames.len() > 0
+                !frames.is_empty()
             });
         },
         _ => {}, // Other items: either not supported, or do not apply
@@ -1442,7 +1442,7 @@ fn mask_mut_leq(rec: &mut Record, target: TargetItem) {
                         false
                     }
                 });
-                frames.len() > 0
+                !frames.is_empty()
             });
         },
         _ => {}, // Other items: either not supported, or do not apply
@@ -1496,7 +1496,7 @@ fn mask_mut_lt(rec: &mut Record, target: TargetItem) {
                         false
                     }
                 });
-                frames.len() > 0
+                !frames.is_empty()
             });
         },
         _ => {}, // Other items: either not supported, or do not apply

--- a/rinex/src/observable.rs
+++ b/rinex/src/observable.rs
@@ -2,11 +2,12 @@ use crate::{carrier, Carrier, Constellation};
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone, PartialEq)]
-pub enum Error {
-    #[error("unknown observable")]
-    UnknownObservable,
-    #[error("malformed observable")]
-    MalformedDescriptor,
+/// Observable Parsing errors
+pub enum ParsingError {
+    #[error("unknown observable \"{0}\"")]
+    UnknownObservable(String),
+    #[error("malformed observable \"{0}\"")]
+    MalformedDescriptor(String),
 }
 
 /// Observable describes all possible observations,
@@ -114,7 +115,7 @@ impl std::fmt::Display for Observable {
 }
 
 impl std::str::FromStr for Observable {
-    type Err = Error;
+    type Err = ParsingError;
     fn from_str(content: &str) -> Result<Self, Self::Err> {
         let content = content.to_uppercase();
         let content = content.trim();
@@ -141,10 +142,10 @@ impl std::str::FromStr for Observable {
                     } else if content.starts_with("D") {
                         Ok(Self::Doppler(content.to_string()))
                     } else {
-                        Err(Error::UnknownObservable)
+                        Err(ParsingError::UnknownObservable(content.to_string()))
                     }
                 } else {
-                    Err(Error::MalformedDescriptor)
+                    Err(ParsingError::MalformedDescriptor(content.to_string()))
                 }
             },
         }

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -97,18 +97,6 @@ impl std::fmt::Display for Crinex {
     }
 }
 
-/// DCB Compensation description
-#[derive(Debug, Clone, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct DcbCompensation {
-    /// Program used for DCBs evaluation and compensation
-    pub program: String,
-    /// Constellation to which this compensation applies to
-    pub constellation: Constellation,
-    /// URL: source of corrections
-    pub url: String,
-}
-
 /// Describes known marker types
 /// Observation Record specific header fields
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -120,8 +108,6 @@ pub struct HeaderFields {
     pub codes: HashMap<Constellation, Vec<Observable>>,
     /// True if local clock drift is compensated for
     pub clock_offset_applied: bool,
-    /// DCBs compensation per constellation basis
-    pub dcb_compensations: Vec<DcbCompensation>,
     /// Optionnal data scalings
     pub scalings: HashMap<Constellation, HashMap<Observable, f64>>,
 }
@@ -144,11 +130,6 @@ impl HeaderFields {
     pub(crate) fn scaling(&self, c: &Constellation, observable: &Observable) -> Option<&f64> {
         let scalings = self.scalings.get(c)?;
         scalings.get(observable)
-    }
-
-    /// Emphasize that DCB is compensated for
-    pub fn append_dcb_compensation(&mut self, dcb: DcbCompensation) {
-        self.dcb_compensations.push(dcb);
     }
 }
 

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -151,7 +151,7 @@ pub trait Combine {
     /// use rinex::observation::*;
     ///
     /// let rinex = Rinex::from_file("../test_resources/OBS/V3/DUTH0630.22O")
-    ///		.unwrap();
+    ///    .unwrap();
     ///
     /// let gf = rinex.geo_free();
     /// for ((ref_observable, rhs_observable), data) in gf {
@@ -202,7 +202,7 @@ pub trait Dcb {
     /// use rinex::observation::*; // .dcb()
     ///
     /// let rinex = Rinex::from_file("../test_resources/OBS/V3/DUTH0630.22O")
-    ///		.unwrap();
+    ///    .unwrap();
     /// let dcb = rinex.dcb();
     /// ```
     fn dcb(&self) -> HashMap<String, BTreeMap<Sv, BTreeMap<(Epoch, EpochFlag), f64>>>;

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -109,25 +109,28 @@ pub struct HeaderFields {
     /// True if local clock drift is compensated for
     pub clock_offset_applied: bool,
     /// Optionnal data scalings
-    pub scalings: HashMap<Constellation, HashMap<Observable, f64>>,
+    pub scalings: HashMap<Constellation, HashMap<Observable, u16>>,
 }
 
 impl HeaderFields {
-    /// Add an optionnal data scaling
-    pub fn with_scaling(&self, c: Constellation, observable: Observable, scaling: f64) -> Self {
-        let mut s = self.clone();
-        if let Some(scalings) = s.scalings.get_mut(&c) {
+    /// Insert a data scaling
+    pub(crate) fn insert_scaling(
+        &mut self,
+        c: Constellation,
+        observable: Observable,
+        scaling: u16,
+    ) {
+        if let Some(scalings) = self.scalings.get_mut(&c) {
             scalings.insert(observable, scaling);
         } else {
-            let mut map: HashMap<Observable, f64> = HashMap::new();
+            let mut map: HashMap<Observable, u16> = HashMap::new();
             map.insert(observable, scaling);
-            s.scalings.insert(c, map);
+            self.scalings.insert(c, map);
         }
-        s
     }
     /// Returns given scaling to apply for given GNSS system
     /// and given observation. Returns 1.0 by default, so it always applies
-    pub(crate) fn scaling(&self, c: &Constellation, observable: &Observable) -> Option<&f64> {
+    pub(crate) fn scaling(&self, c: &Constellation, observable: &Observable) -> Option<&u16> {
         let scalings = self.scalings.get(c)?;
         scalings.get(observable)
     }

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -109,7 +109,7 @@ pub struct HeaderFields {
     /// True if local clock drift is compensated for
     pub clock_offset_applied: bool,
     /// Optionnal data scalings
-    pub scalings: HashMap<Constellation, HashMap<Observable, u16>>,
+    pub scalings: HashMap<(Constellation, Observable), u16>,
 }
 
 impl HeaderFields {
@@ -120,19 +120,12 @@ impl HeaderFields {
         observable: Observable,
         scaling: u16,
     ) {
-        if let Some(scalings) = self.scalings.get_mut(&c) {
-            scalings.insert(observable, scaling);
-        } else {
-            let mut map: HashMap<Observable, u16> = HashMap::new();
-            map.insert(observable, scaling);
-            self.scalings.insert(c, map);
-        }
+        self.scalings.insert((c, observable), scaling);
     }
     /// Returns given scaling to apply for given GNSS system
     /// and given observation. Returns 1.0 by default, so it always applies
-    pub(crate) fn scaling(&self, c: &Constellation, observable: &Observable) -> Option<&u16> {
-        let scalings = self.scalings.get(c)?;
-        scalings.get(observable)
+    pub(crate) fn scaling(&self, c: Constellation, observable: Observable) -> Option<&u16> {
+        self.scalings.get(&(c, observable))
     }
 }
 

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -97,6 +97,18 @@ impl std::fmt::Display for Crinex {
     }
 }
 
+/// DCB Compensation description
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DcbCompensation {
+    /// Program used for DCBs evaluation and compensation
+    pub program: String,
+    /// Constellation to which this compensation applies to
+    pub constellation: Constellation,
+    /// URL: source of corrections
+    pub url: String,
+}
+
 /// Describes known marker types
 /// Observation Record specific header fields
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -109,7 +121,7 @@ pub struct HeaderFields {
     /// True if local clock drift is compensated for
     pub clock_offset_applied: bool,
     /// DCBs compensation per constellation basis
-    pub dcb_compensations: Vec<Constellation>,
+    pub dcb_compensations: Vec<DcbCompensation>,
     /// Optionnal data scalings
     pub scalings: HashMap<Constellation, HashMap<Observable, f64>>,
 }
@@ -135,38 +147,8 @@ impl HeaderFields {
     }
 
     /// Emphasize that DCB is compensated for
-    pub fn with_dcb_compensation(&self, c: Constellation) -> Self {
-        let mut s = self.clone();
-        s.dcb_compensations.push(c);
-        s
-    }
-    /// Returns true if DCB compensation was applied for given constellation.
-    /// If constellation is None: we test against all encountered constellation
-    pub fn dcb_compensation(&self, c: Option<Constellation>) -> bool {
-        if let Some(c) = c {
-            for comp in &self.dcb_compensations {
-                if *comp == c {
-                    return true;
-                }
-            }
-            false
-        } else {
-            for (cst, _) in &self.codes {
-                // all encountered constellations
-                let mut found = false;
-                for ccst in &self.dcb_compensations {
-                    // all compensated constellations
-                    if ccst == cst {
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    return false;
-                }
-            }
-            true
-        }
+    pub fn append_dcb_compensation(&mut self, dcb: DcbCompensation) {
+        self.dcb_compensations.push(dcb);
     }
 }
 

--- a/rinex/src/observation/mod.rs
+++ b/rinex/src/observation/mod.rs
@@ -129,13 +129,9 @@ impl HeaderFields {
     }
     /// Returns given scaling to apply for given GNSS system
     /// and given observation. Returns 1.0 by default, so it always applies
-    pub fn scaling(&self, c: &Constellation, observable: Observable) -> f64 {
-        if let Some(scalings) = self.scalings.get(c) {
-            if let Some(scaling) = scalings.get(&observable) {
-                return *scaling;
-            }
-        }
-        1.0
+    pub(crate) fn scaling(&self, c: &Constellation, observable: &Observable) -> Option<&f64> {
+        let scalings = self.scalings.get(c)?;
+        scalings.get(observable)
     }
 
     /// Emphasize that DCB is compensated for

--- a/rinex/src/observation/record.rs
+++ b/rinex/src/observation/record.rs
@@ -1684,10 +1684,10 @@ impl Dcb for Record {
         for (epoch, (_, vehicles)) in self {
             for (sv, observations) in vehicles {
                 for (lhs_observable, lhs_observation) in observations {
-                    if !lhs_observable.is_phase_observable() {
-                        if !lhs_observable.is_pseudorange_observable() {
-                            continue;
-                        }
+                    if !lhs_observable.is_phase_observable()
+                        && !lhs_observable.is_pseudorange_observable()
+                    {
+                        continue;
                     }
                     let lhs_code = lhs_observable.to_string();
                     let lhs_carrier = &lhs_code[1..2];

--- a/rinex/src/observation/record.rs
+++ b/rinex/src/observation/record.rs
@@ -17,8 +17,8 @@ pub enum Error {
     EpochError(#[from] epoch::Error),
     #[error("constellation parsing error")]
     ConstellationParsing(#[from] constellation::ParsingError),
-    #[error("failed to parse sv")]
-    SvError(#[from] sv::Error),
+    #[error("sv parsing error")]
+    SvParsing(#[from] sv::ParsingError),
     #[error("failed to parse integer number")]
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("failed to parse float number")]

--- a/rinex/src/observation/record.rs
+++ b/rinex/src/observation/record.rs
@@ -15,8 +15,8 @@ use hifitime::Duration;
 pub enum Error {
     #[error("failed to parse epoch")]
     EpochError(#[from] epoch::Error),
-    #[error("failed to identify constellation")]
-    ConstellationError(#[from] constellation::Error),
+    #[error("constellation parsing error")]
+    ConstellationParsing(#[from] constellation::ParsingError),
     #[error("failed to parse sv")]
     SvError(#[from] sv::Error),
     #[error("failed to parse integer number")]

--- a/rinex/src/sv.rs
+++ b/rinex/src/sv.rs
@@ -19,7 +19,7 @@ pub struct Sv {
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum Error {
     #[error("unknown constellation")]
-    ConstellationError(#[from] constellation::Error),
+    ConstellationError(#[from] constellation::ParsingError),
     #[error("failed to parse prn")]
     ParseIntError(#[from] std::num::ParseIntError),
 }

--- a/rinex/src/sv.rs
+++ b/rinex/src/sv.rs
@@ -17,11 +17,11 @@ pub struct Sv {
 
 /// ̀`Sv` parsing & identification related errors
 #[derive(Error, Debug, Clone, PartialEq)]
-pub enum Error {
-    #[error("unknown constellation")]
-    ConstellationError(#[from] constellation::ParsingError),
-    #[error("failed to parse prn")]
-    ParseIntError(#[from] std::num::ParseIntError),
+pub enum ParsingError {
+    #[error("constellation parsing error")]
+    ConstellationParsing(#[from] constellation::ParsingError),
+    #[error("sv prn# parsing error")]
+    PRNParsing(#[from] std::num::ParseIntError),
 }
 
 impl Sv {
@@ -32,7 +32,7 @@ impl Sv {
 }
 
 impl std::str::FromStr for Sv {
-    type Err = Error;
+    type Err = ParsingError;
     /// Builds an `Sv` from XYY identification code.   
     /// code should strictly follow rinex conventions.   
     /// This method tolerates trailing whitespaces

--- a/rinex/src/types.rs
+++ b/rinex/src/types.rs
@@ -1,6 +1,6 @@
-//! `RINEX` files type description
-use super::Constellation;
-use thiserror::Error;
+//! `RINEX` types description
+use crate::header::ParsingError;
+use crate::prelude::Constellation;
 
 /// Describes all known `RINEX` file types
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
@@ -27,13 +27,6 @@ pub enum Type {
     /// Users interested in such calibrations / conversions / calculations,
     /// should use this parser as a mean to extract the antenna coefficients solely
     AntennaData,
-}
-
-#[derive(Error, Debug)]
-/// `Type` related errors
-pub enum TypeError {
-    #[error("Unknown RINEX type identifier \"{0}\"")]
-    UnknownType(String),
 }
 
 impl std::fmt::Display for Type {
@@ -67,7 +60,7 @@ impl Type {
 }
 
 impl std::str::FromStr for Type {
-    type Err = TypeError;
+    type Err = ParsingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.eq("NAVIGATION DATA") {
             Ok(Self::NavigationData)
@@ -84,7 +77,7 @@ impl std::str::FromStr for Type {
         } else if s.eq("IONOSPHERE MAPS") {
             Ok(Self::IonosphereMaps)
         } else {
-            Err(TypeError::UnknownType(String::from(s)))
+            Err(ParsingError::TypeParsing(String::from(s)))
         }
     }
 }

--- a/rinex/src/version.rs
+++ b/rinex/src/version.rs
@@ -1,4 +1,5 @@
 //! `RINEX` revision description
+use thiserror::Error;
 
 /// Current `RINEX` version supported to this day
 pub const SUPPORTED_VERSION: Version = Version { major: 4, minor: 0 };
@@ -11,6 +12,14 @@ pub struct Version {
     pub major: u8,
     /// Version minor number
     pub minor: u8,
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum ParsingError {
+    #[error("non supported version \"{0}\"")]
+    NotSupported(String),
+    #[error("failed to parse version")]
+    ParseIntError(#[from] std::num::ParseIntError),
 }
 
 impl Default for Version {
@@ -78,7 +87,7 @@ impl Into<(u8, u8)> for Version {
 }
 
 impl std::str::FromStr for Version {
-    type Err = std::num::ParseIntError;
+    type Err = ParsingError; 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.contains(".") {
             true => {

--- a/rinex/src/version.rs
+++ b/rinex/src/version.rs
@@ -87,7 +87,7 @@ impl Into<(u8, u8)> for Version {
 }
 
 impl std::str::FromStr for Version {
-    type Err = ParsingError; 
+    type Err = ParsingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.contains(".") {
             true => {

--- a/sinex/Cargo.toml
+++ b/sinex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sinex"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["Guillaume W. Bres <guillaume.bressaix@gmail.com>"]
 description = "Package to parse and analyze SINEX data"

--- a/sinex/src/bias/mod.rs
+++ b/sinex/src/bias/mod.rs
@@ -31,7 +31,7 @@ impl std::str::FromStr for TimeSystem {
         } else if content.eq("TAI") {
             Ok(Self::TAI)
         } else {
-            if let Ok(c) = Constellation::from_1_letter_code(content) {
+            if let Ok(c) = Constellation::from_str(content) {
                 Ok(Self::GNSS(c))
             } else {
                 Err(TimeSystemError::UnknownSystem(content.to_string()))

--- a/sinex/src/lib.rs
+++ b/sinex/src/lib.rs
@@ -198,14 +198,14 @@ impl Sinex {
                                 bias_description = bias_description.with_time_system(system)
                             },
                             "RECEIVER_CLOCK_REFERENCE_GNSS" => {
-                                if let Ok(c) = Constellation::from_1_letter_code(content.trim()) {
+                                if let Ok(c) = Constellation::from_str(content.trim()) {
                                     bias_description = bias_description.with_rcvr_clock_ref(c)
                                 }
                             },
                             "SATELLITE_CLOCK_REFERENCE_OBSERVABLES" => {
                                 let items: Vec<&str> =
                                     content.trim().split_ascii_whitespace().collect();
-                                if let Ok(c) = Constellation::from_1_letter_code(items[0]) {
+                                if let Ok(c) = Constellation::from_str(items[0]) {
                                     if items.len() == 1 {
                                         // --> no observable given
                                         let mut map: HashMap<Constellation, Vec<String>> =

--- a/sinex/src/receiver.rs
+++ b/sinex/src/receiver.rs
@@ -41,7 +41,7 @@ impl std::str::FromStr for Receiver {
         Ok(Receiver {
             station: station.trim().to_string(),
             constellation: {
-                if let Ok(c) = Constellation::from_1_letter_code(constellation.trim()) {
+                if let Ok(c) = Constellation::from_str(constellation.trim()) {
                     Some(c)
                 } else {
                     None


### PR DESCRIPTION
- [x] Rinex 0.13.0
- [x] Sinex 0.2.1 : minor benefits, from v0.13.0 improvements

Improved overall Parsing error reporting: use less generic errors like std::float::error or num::int:error,
use meaningful errors instead: this makes debugging much easier.

New features
  - [x] DCB compensations are now correctly parsed and user API 
(in case this file came with such compensation)
  - [x] PCV compensations are now correctly parsed and introduce their user API
(in case this file came with such compensation)
  - [x] Good progress towards High Precision RINEX support. Although we cannot test it due to unavailable data.
Scaling factors are now supposedly correctly parsed, at least if they fit on one line. Update the (phase data) API to take possible scaling into account (high precision context)