### PR TITLE
sinex: Fix deprecation warning of `NaiveDateTime::and_hms` by replacing with `and_hms_opt`.

### DIFF
--- a/sinex/src/datetime.rs
+++ b/sinex/src/datetime.rs
@@ -17,7 +17,7 @@ pub fn parse_datetime(content: &str) -> Result<chrono::NaiveDateTime, ParseDateT
     let h = secs / 3600.0;
     let m = (secs - h * 3600.0) / 60.0;
     let s = secs - h * 3600.0 - m * 60.0;
-    Ok(dt.and_hms(h as u32, m as u32, s as u32))
+    Ok(dt.and_hms_opt(h as u32, m as u32, s as u32).unwrap())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The [newer implementation](https://docs.rs/chrono/0.4.31/chrono/naive/struct.NaiveDate.html#method.and_hms_opt) doesn't panic but might return `None` instead.
While this patch simply unwraps the result fixing the deprecation warning, it should probably handle `None` separately.