### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,15 @@ jobs:
         - build: linux
           os: ubuntu-latest
           rust: stable
+          target: x86_64-unknown-linux-gnu
+        - build: linux
+          os: ubuntu-latest
+          rust: stable
           target: x86_64-unknown-linux-musl
+        - build: macos
+          os: macos-latest
+          rust: nightly
+          target: x86_64-apple-darwin
         - build: macos
           os: macos-latest
           rust: nightly
@@ -95,9 +103,14 @@ jobs:
     - name: Build applications
       shell: bash
       run: |
-        ${{ env.CARGO }} build --verbose --target ${{ matrix.target }} -r -p rinex-cli -p rnx2cggtts -p rnx2crx -p crx2rnx -p ublox-rnx
-        ls -lah target
-        ls -lah target/${{ matrix.target }}
+        CARGO_PROFILE_RELEASE_STRIP=symbols ${{ env.CARGO }} build --verbose \
+          --target ${{ matrix.target }} -r \
+          -p rinex-cli \
+          -p rnx2cggtts \
+          -p rnx2crx \
+          -p crx2rnx \
+          -p ublox-rnx
+        ls -lah target/${{ matrix.target }}/release
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           crx2rnx="target/${{ matrix.target }}/release/crx2rnx.exe"
           rnx2crx="target/${{ matrix.target }}/release/rnx2crx.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,7 @@ jobs:
     name: build
     runs-on: ${{ matrix.os }}
     env:
-      # For some builds, we use cross to test on 32-bit and big-endian
-      # systems.
       CARGO: cargo
-      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS: ''
-      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
-      TARGET_DIR: ./target
-      # Bump this as appropriate. We pin to a version to make sure CI
-      # continues to work as cross releases in the past have broken things
-      # in subtle ways.
-      CROSS_VERSION: v0.2.5
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
     strategy:
@@ -72,39 +62,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libudev-dev
 
-    - name: Use Cross
-      if: matrix.os == 'ubuntu-latest' && matrix.target != ''
-      shell: bash
-      run: |
-        # In the past, new releases of 'cross' have broken CI. So for now, we
-        # pin it. We also use their pre-compiled binary releases because cross
-        # has over 100 dependencies and takes a bit to compile.
-        dir="$RUNNER_TEMP/cross-download"
-        mkdir "$dir"
-        echo "$dir" >> $GITHUB_PATH
-        cd "$dir"
-        curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
-        tar xf cross-x86_64-unknown-linux-musl.tar.gz
-        echo "CARGO=cross" >> $GITHUB_ENV
-
-    - name: Set target variables
-      shell: bash
-      run: |
-        echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-        echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
-
-    - name: Show command used for Cargo
-      shell: bash
-      run: |
-        echo "cargo command is: ${{ env.CARGO }}"
-        echo "target flag is: ${{ env.TARGET_FLAGS }}"
-        echo "target dir is: ${{ env.TARGET_DIR }}"
-
     - name: Build applications
       shell: bash
       run: |
-        CARGO_PROFILE_RELEASE_STRIP=symbols ${{ env.CARGO }} build --verbose \
-          --target ${{ matrix.target }} -r \
+        CARGO_PROFILE_RELEASE_STRIP=symbols ${{ env.CARGO }} build \
+          --verbose \
+          --target ${{ matrix.target }} \
+          --all-features \
+          --release \
           -p rinex-cli \
           -p rnx2cggtts \
           -p rnx2crx \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,19 @@ jobs:
           target: x86_64-unknown-linux-musl
         - build: macos
           os: macos-latest
-          rust: nightly
+          rust: stable
           target: x86_64-apple-darwin
         - build: macos
           os: macos-latest
-          rust: nightly
+          rust: stable
           target: aarch64-apple-darwin
         - build: win64-msvc
           os: windows-latest
-          rust: nightly
+          rust: stable
           target: x86_64-pc-windows-msvc
         - build: win64-gnu
           os: windows-latest
-          rust: nightly-x86_64-gnu
+          rust: stable-x86_64-gnu
           target: x86_64-pc-windows-gnu
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ members = [
 ]
 
 exclude = ["./test_resources"]
-
-[profile.release]
-strip = "symbols"


### PR DESCRIPTION
- remove cargo.release profile, it's better to customize this in the CI script rather than stripping any _released_ binaries to ever be produced in the workspace
- add x86_64-unknown-linux-gnu which seems to the standard linux target
- add macos-x86: trying to see if the current macos triggers the same link error