### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: build
     runs-on: ${{ matrix.os }}
+    # continue even though build failed for one or more targets
+    continue-on-error: true
     env:
       CARGO: cargo
       # Emit backtraces on panics.
@@ -133,9 +135,12 @@ jobs:
           ${{ env.ASSET }}
           ${{ env.ASSET_SUM }}
   
-  release:
+  create:
     runs-on: ubuntu-latest
     needs: ['build']
+    # continue even though we failed to download or upload one
+    # or more artefacts
+    continue-on-error: true
     steps:
     - name: Create Release
       id: create_release
@@ -146,3 +151,153 @@ jobs:
         draft: true
         tag_name: ${{ github.ref_name }}
         release_name: ${{ github.ref_name }}
+
+    - name: Download x86_64-unknown-linux-gnu
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+    
+    - name: Download x86_64-unknown-linux-gnu (cksum)
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+        
+    - name: Upload x86_64-unknown-linux-gnu
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+        asset_name: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+        asset_content_type: application/gzip
+        
+    - name: Upload x86_64-unknown-linux-gnu (cksum)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+        asset_name: rinex-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+        asset_content_type: application/gzip
+        
+    - name: Download x86_64-apple-darwin
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
+    
+    - name: Download x86_64-apple-darwin (cksum)
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz.sha256
+        
+    - name: Upload x86_64-apple-darwin
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
+        asset_name: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
+        asset_content_type: application/gzip
+        
+    - name: Upload x86_64-apple-darwin (cksum)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz.sha256
+        asset_name: rinex-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz.sha256
+        asset_content_type: application/gzip
+    
+    - name: Download aarch64-apple-darwin
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz
+    
+    - name: Download aarch64-apple-darwin (cksum)
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz.sha256
+        
+    - name: Upload aarch64-apple-darwin
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz
+        asset_name: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz
+        asset_content_type: application/gzip
+        
+    - name: Upload aarch64-apple-darwin (cksum)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz.sha256
+        asset_name: rinex-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz.sha256
+        asset_content_type: application/gzip
+
+    - name: Download x86_64-pc-windows-msvc
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+    
+    - name: Download x86_64-pc-windows-msvc (cksum)
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip.sha256
+        
+    - name: Upload x86_64-pc-windows-msvc
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+        asset_name: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+        asset_content_type: application/zip
+        
+    - name: Upload x86_64-pc-windows-msvc (cksum)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip.sha256
+        asset_name: rinex-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip.sha256
+        asset_content_type: application/zip
+
+    - name: x86_64-pc-windows-gnu
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip
+    
+    - name: Download x86_64-pc-windows-gnu (cksum)
+      uses: actions/download-artifact@v3
+      with: 
+        name: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip.sha256
+        
+    - name: Upload x86_64-pc-windows-gnu
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip
+        asset_name: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip
+        asset_content_type: application/zip
+        
+    - name: Upload x86_64-pc-windows-gnu (cksum)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip.sha256
+        asset_name: rinex-${{ github.ref_name }}-x86_64-pc-windows-gnu.zip.sha256
+        asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           ${{ env.ASSET }}
           ${{ env.ASSET_SUM }}
   
-  create:
+  release:
     runs-on: ubuntu-latest
     needs: ['build']
     # continue even though we failed to download or upload one


### PR DESCRIPTION
* download the artifacts
* upload the binaries
* continue-on-error
  - tolerate build failures.
  For some reason the windows-gnu is currently in failure, but it only represents 20% of our targets.
  - tolerate typos in the download/upload steps.
  The dl/ul process is tedious. We might be able to improve that in the future, for example with a strategy on `target`, like in the build step. But the Release steps are highly sensitive.