### PR TITLE
Update old links to GeoRust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 RINEX 
 =====
 
-[![Rust](https://github.com/gwbres/rinex/actions/workflows/rust.yml/badge.svg)](https://github.com/gwbres/rinex/actions/workflows/rust.yml)
+[![Rust](https://github.com/georust/rinex/actions/workflows/rust.yml/badge.svg)](https://github.com/georust/rinex/actions/workflows/rust.yml)
 [![crates.io](https://docs.rs/rinex/badge.svg)](https://docs.rs/rinex/)
 [![crates.io](https://img.shields.io/crates/d/rinex.svg)](https://crates.io/crates/rinex)
 
 [![minimum rustc: 1.64](https://img.shields.io/badge/minimum%20rustc-1.64-blue?logo=rust)](https://www.whatrustisit.com)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-MIT) 
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-MIT) 
 
 Rust tool suites to parse, analyze and process [RINEX Data](https://en.wikipedia.org/wiki/RINEX).
 
@@ -64,7 +64,7 @@ your improvements
 It supports some of `teqc` operations.
 It integrates a position solver and can format CGGTTS tracks for clock comparison.
 The application is auto-generated for a few architectures, download it from the 
-[release portal](https://github.com/gwbres/rinex/releases)
+[release portal](https://github.com/georust/rinex/releases)
 
 * [`sp3`](sp3/) High Precision Orbits (by IGS) 
 * [`rnx2crx`](rnx2crx/) is a RINEX compressor (RINEX to Compact RINEX)

--- a/crx2rnx/README.md
+++ b/crx2rnx/README.md
@@ -2,7 +2,7 @@ CRX2RNX
 =======
 
 [![crates.io](https://img.shields.io/crates/v/crx2rnx.svg)](https://crates.io/crates/crx2rnx)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/hatanaka/rinex/main/LICENSE-MIT) 
 
 `CRX2RNX` is a command line tool to decompress Compact RINEX into `RINEX` data.  

--- a/rinex-cli/README.md
+++ b/rinex-cli/README.md
@@ -2,8 +2,8 @@ RINEX-cli
 =========
 
 [![crates.io](https://img.shields.io/crates/v/rinex-cli.svg)](https://crates.io/crates/rinex-cli)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-MIT) 
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-MIT) 
 
 `rinex-cli` is a command line application to post process RINEX data.  
 It can be used to reshape your RINEX files, perform basic geodesic calculations,

--- a/rinex-cli/doc/analysis.md
+++ b/rinex-cli/doc/analysis.md
@@ -16,7 +16,7 @@ rinex-cli \
     --retain-sv G01,G08,R04,R08,R09 --sv-epoch
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/sv_esbc00dnk.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/sv_esbc00dnk.png">
 
 
 In case Differential context is activated (`--nav`) determining
@@ -39,7 +39,7 @@ rinex-cli \
     -P G01,G08,R04,R08,R09 --sv
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/sv_diff_esbc00dnk.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/sv_diff_esbc00dnk.png">
 
 With this command, user can rapidly determine which vehicle is eligible for
 RINEX differential processing. In this example, R04, R08 and R09 are excellent candidates,
@@ -47,7 +47,7 @@ because most of the Observation context is covered by Ephemeris.
 
 To learn more about differential processing, refer to the 
 Differential proceesing operations described
-[in this page](https://github.com/gwbres/rinex/blob/main/rinex-cli/doc/processing.md).
+[in this page](https://github.com/georust/rinex/blob/main/rinex-cli/doc/processing.md).
 
 Sample rate analysis
 ====================
@@ -61,9 +61,9 @@ For example, `ESBC00DNK_R_20201` is a large file with steady 30s sample rate.
 rinex-cli --fp test_resources/CRNX/V3/ESBC00DNK_R_20201770000_01D_30S_MO.crx.gz --epoch-hist
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_hist.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_hist.png">
 
 When applying to non-steady files, this plot emphasizes the average (dominant) sample rate and the amount of anomalies.   
 In this example, 16 epochs were generated, dominant sample rate is 30s and 2 epochs are missing.
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/hist2.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/hist2.png">

--- a/rinex-cli/doc/cycle-slip.md
+++ b/rinex-cli/doc/cycle-slip.md
@@ -24,7 +24,7 @@ rinex-cli \
        -P R21,R12 ">=2020-06-25T00:00:00 UTC" "<=2020-06-25T12:00:00 UTC"
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_glo_cs_zoom.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_glo_cs_zoom.png">
 
 Almost all epochs at the beginning of the day were affected for R12(L3) and one or two for R21(L2).  
 All GPS vehicles are sane, 95% of Glonass vehicles are sane too.

--- a/rinex-cli/doc/gnss-combination.md
+++ b/rinex-cli/doc/gnss-combination.md
@@ -76,7 +76,7 @@ rinex-cli \
         --gf
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_gf.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_gf.png">
 
 Several combinations were formed, like C1W-C2W meaning PR 1W against PR 2W,
 both L1 and L2 signals were sampled for both vehicles, but L5 is also sampled for G08.
@@ -93,7 +93,7 @@ Let's focus on Phase data only:
             --gf
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_gf_zoom.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_gf_zoom.png">
 
 GF and atmospheric delay
 ========================
@@ -123,7 +123,7 @@ rinex-cli \
             --gf
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_gfcs.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_gfcs.png">
 
 Discontinuities in GF slopes indicate bad reception conditions and CSs.  
 You can see that this one is not reported by the receiver.  

--- a/rinex-cli/doc/positioning.md
+++ b/rinex-cli/doc/positioning.md
@@ -135,11 +135,11 @@ you set the `-q` quite option.
 
 One output is the local GNSS receiver time and the dilution of precision on the time component :
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/clk_tdop.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/clk_tdop.png">
 
 The vertical and horizontal dilution of precision are also depicted :
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/hdop_vdop.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/hdop_vdop.png">
 
 ## Current limitations
 

--- a/rinex-cli/doc/processing.md
+++ b/rinex-cli/doc/processing.md
@@ -58,7 +58,7 @@ rinex-cli \
         -P G07 --dcb
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_ph_dcbs.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_ph_dcbs.png">
 
 
 Code Multipath biases
@@ -89,7 +89,7 @@ rinex-cli \
         -P G13 --dcb --mp
 ```
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_g13_dcb_mp.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_g13_dcb_mp.png">
 
 Differential Processing
 =======================

--- a/rinex-cli/doc/record.md
+++ b/rinex-cli/doc/record.md
@@ -15,7 +15,7 @@ rinex-cli \
 
 The received signal power analysis for example, extracted from the analysis report
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_ssi.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_ssi.png">
 
 It is rapidly necessary to determine which vehicles can be encountered in a file.  
 For this reason, we developped the `--sv-epoch` analysis, which helps determine which vehicle to focus on.
@@ -28,7 +28,7 @@ rinex-cli \
 
 With the Sv per Epoch analysis, you know R01,R02 were both seen at 21:00UTC
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_sv_epoch.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_sv_epoch.png">
 
 
 When dealing with Observation RINEX, the following operations are most useful:
@@ -57,7 +57,7 @@ for easy phase variations comparison.
 We also emphasize _possible_ cycle slips when plotting with a black symbol. 
 For example L5 of G10 in `GRAS00FRA_R_2022` is affected:
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/gras00fra_g10phase.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/gras00fra_g10phase.png">
 
 4 micro (1 tick long) possible corruptions over this channel, which was used to sample L5 at high rate. 
 
@@ -86,7 +86,7 @@ rinex-cli \
 
 From the resuling "sv.png" product:
 
-<img align="center" width="650" src="https://github.com/gwbres/rinex/blob/main/doc/plots/esbc00dnk_gps_obs_nav_sv.png">
+<img align="center" width="650" src="https://github.com/georust/rinex/blob/main/doc/plots/esbc00dnk_gps_obs_nav_sv.png">
 
 Triangles mark ephemeris frames (low rate) and circles mark observations (high rate).   
 G25, G29, G31 and G12 in 20% to 35% portion of that day, have enough elevation angle information for the enhancement

--- a/rnx2crx/README.md
+++ b/rnx2crx/README.md
@@ -2,7 +2,7 @@ RNX2CRX
 =======
 
 [![crates.io](https://img.shields.io/crates/v/rnx2crx.svg)](https://crates.io/crates/rnx2crx)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/hatanaka/rinex/main/LICENSE-MIT) 
 
 `RNX2CRX` is a command line tool to compress `RINEX` data into

--- a/sinex/README.md
+++ b/sinex/README.md
@@ -2,8 +2,8 @@ SINEX
 =====
 
 [![crates.io](https://img.shields.io/crates/v/sinex.svg)](https://crates.io/crates/sinex)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-APACHE)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/rinex/blob/main/LICENSE-MIT)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/georust/rinex/blob/main/LICENSE-MIT)
 
 ## Parser
 

--- a/ublox-rnx/src/main.rs
+++ b/ublox-rnx/src/main.rs
@@ -1,6 +1,6 @@
 //! Application to generate RINEX data in standard format
 //! using a Ublox receiver.   
-//! Homepage: <https://github.com/gwbres/rinex>
+//! Homepage: <https://github.com/georust/rinex>
 use std::str::FromStr;
 
 use thiserror::Error;


### PR DESCRIPTION
Simply updates a lot of `gwbres/rinex` links to `georust/rinex`.