### PR TITLE
Fix rinex-cli interpretation of rx-geo

### DIFF
--- a/rinex-cli/src/cli/mod.rs
+++ b/rinex-cli/src/cli/mod.rs
@@ -11,8 +11,6 @@ use rinex::prelude::*;
 
 use crate::fops::open_with_web_browser;
 
-use map_3d::{geodetic2ecef, Ellipsoid};
-
 // identification mode
 mod identify;
 // graph mode
@@ -296,8 +294,8 @@ Otherwise it gets automatically picked up."))
     pub fn manual_position(&self) -> Option<(f64, f64, f64)> {
         if let Some(position) = self.manual_ecef() {
             Some(position)
-        } else if let Some((lat, lon, alt)) = self.manual_geodetic() {
-            Some(geodetic2ecef(lat, lon, alt, Ellipsoid::WGS84))
+        } else if let Some(position) = self.manual_geodetic() {
+            Some(GroundPosition::from_geodetic(position).to_ecef_wgs84())
         } else {
             None
         }


### PR DESCRIPTION
The rx-geo parameter expects lat/lon in degrees, but the geodetic2ecef function wants them in radians. This leads to positions being wildly incorrect. This commit switches to calling the GroundPosition::from_geodetic function instead, which is happy to directly recieve the lat/lon/alt tuple as-is without conversion.