### PR TITLE
OBS V3 formatting

### DIFF
--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -29,9 +29,10 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::str::FromStr;
 
-use gnss::constellation::ParsingError as ConstellationParsingError;
-use hifitime::Epoch;
+use hifitime::{Epoch, Unit};
 use thiserror::Error;
+
+use gnss::constellation::ParsingError as ConstellationParsingError;
 
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -1567,7 +1568,8 @@ impl Header {
     fn fmt_observation_rinex(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Some(obs) = &self.obs {
             if let Some(e) = obs.time_of_first_obs {
-                let (y, m, d, hh, mm, ss, nanos) = e.to_gregorian_utc();
+                let (y, m, d, hh, mm, ss, nanos) =
+                    (e + e.leap_seconds(true).unwrap_or(0.0) * Unit::Second).to_gregorian_utc();
                 writeln!(
                     f,
                     "{}",
@@ -1581,7 +1583,8 @@ impl Header {
                 )?;
             }
             if let Some(e) = obs.time_of_last_obs {
-                let (y, m, d, hh, mm, ss, nanos) = e.to_gregorian_utc();
+                let (y, m, d, hh, mm, ss, nanos) =
+                    (e + e.leap_seconds(true).unwrap_or(0.0) * Unit::Second).to_gregorian_utc();
                 writeln!(
                     f,
                     "{}",

--- a/rinex/src/observation/record.rs
+++ b/rinex/src/observation/record.rs
@@ -623,7 +623,7 @@ fn fmt_epoch_v3(
         }
         lines.push('\n');
     }
-    lines
+    lines.trim_end().to_string()
 }
 
 fn fmt_epoch_v2(

--- a/rinex/src/observation/record.rs
+++ b/rinex/src/observation/record.rs
@@ -623,7 +623,8 @@ fn fmt_epoch_v3(
         }
         lines.push('\n');
     }
-    lines.trim_end().to_string()
+    lines.truncate(lines.trim_end().len());
+    lines
 }
 
 fn fmt_epoch_v2(

--- a/rinex/src/tests/production.rs
+++ b/rinex/src/tests/production.rs
@@ -46,7 +46,6 @@ mod test {
     }
     #[test]
     #[cfg(feature = "flate2")]
-    #[ignore]
     fn obs_v3() {
         let folder = env!("CARGO_MANIFEST_DIR").to_owned() + "/../test_resources/OBS/V3/";
         for file in std::fs::read_dir(folder).unwrap() {


### PR DESCRIPTION
- [x] fixes minor issue that caused OBS(V3) formatting to be wrong
- [x] unlock dedicated test
- [x] correct the timestamp that we format as `TIME_OF_FIRST OBS` and `TIME_OF_LAST OBS`   