### PR TITLE
switch from chrono::Duration to chrono::TimeDelta

### DIFF
--- a/rinex-cli/src/teqc/ascii_plot.rs
+++ b/rinex-cli/src/teqc/ascii_plot.rs
@@ -52,7 +52,7 @@ pub fn ascii_plot (x_width: u32, obs_rinex: &Rinex, nav_rinex: Option<Rinex>) ->
     epochs.sort();
     let time_span = epochs[epochs.len()-1].date - epochs[0].date;
     let px_secs = time_span.num_seconds() as u32 / x_width; // nb of secs per px
-    let dt_granularity = chrono::Duration::from_std(std::time::Duration::from_secs(px_secs.into())).unwrap();
+    let dt_granularity = chrono::TimeDelta::from_std(std::time::Duration::from_secs(px_secs.into())).unwrap();
     
     // list vehicles, on an epoch basis
     let mut vehicles = obs_rinex.space_vehicles();

--- a/sinex/src/bias/mod.rs
+++ b/sinex/src/bias/mod.rs
@@ -184,7 +184,7 @@ impl std::str::FromStr for Solution {
 
 impl Solution {
     /// Returns duration for this bias solution
-    pub fn duration(&self) -> chrono::Duration {
+    pub fn duration(&self) -> chrono::TimeDelta {
         self.end_time - self.start_time
     }
 }


### PR DESCRIPTION
Duration is now simply an alias of TimeDelta kept for backwards compatibility. 