### PR TITLE
Swap latitude and longitude in GPX output

### DIFF
--- a/rinex-cli/src/cli/fops/filegen.rs
+++ b/rinex-cli/src/cli/fops/filegen.rs
@@ -1,9 +1,5 @@
 // filegen opmode
-use clap::{
-    Command,
-    //ArgAction,
-    //value_parser,
-};
+use clap::Command;
 
 use super::{SHARED_DATA_ARGS, SHARED_GENERAL_ARGS};
 

--- a/rinex-cli/src/positioning/ppp/post_process.rs
+++ b/rinex-cli/src/positioning/ppp/post_process.rs
@@ -262,7 +262,7 @@ pub fn post_process(
         )?;
         if matches.get_flag("gpx") {
             let mut segment = gpx::TrackSegment::new();
-            let mut wp = Waypoint::new(GeoPoint::new(rad2deg(lon), rad2deg(lat)));  // Yes, longitude *then* latitude
+            let mut wp = Waypoint::new(GeoPoint::new(rad2deg(lon), rad2deg(lat))); // Yes, longitude *then* latitude
             wp.elevation = Some(alt);
             wp.speed = None; // TODO ?
             wp.time = None; // TODO Gpx::Time

--- a/rinex-cli/src/positioning/ppp/post_process.rs
+++ b/rinex-cli/src/positioning/ppp/post_process.rs
@@ -262,7 +262,7 @@ pub fn post_process(
         )?;
         if matches.get_flag("gpx") {
             let mut segment = gpx::TrackSegment::new();
-            let mut wp = Waypoint::new(GeoPoint::new(rad2deg(lat), rad2deg(lon)));
+            let mut wp = Waypoint::new(GeoPoint::new(rad2deg(lon), rad2deg(lat)));  // Yes, longitude *then* latitude
             wp.elevation = Some(alt);
             wp.speed = None; // TODO ?
             wp.time = None; // TODO Gpx::Time


### PR DESCRIPTION
The geo_point::Point is initalized with an (X, Y) coordinate, which it interprets as (longitude, latitude). We currently intialize the point in the wrong order which results in incorrect GPX output.