### PR TITLE
Fix SV_Elev plotting in coherent OBS/NAV/SP3 rinex scenarios

### DIFF
--- a/rinex/src/lib.rs
+++ b/rinex/src/lib.rs
@@ -2318,8 +2318,9 @@ impl Rinex {
         }))
     }
     /// Interpolates SV position, expressed in meters ECEF at desired Epoch `t`.
-    /// An interpolation order of at least 7 is recommended.
-    /// Operation is not feasible if sampling interval cannot be determined.
+    /// An interpolation order between 4 and 8 is recommended, depending on the
+    /// precision you are targetting. Higher orders do not make sense considering the
+    /// noise on broadcasted (real time) positions.
     /// In ideal scenarios, Broadcast Ephemeris are complete and evenly spaced in time:
     ///   - the first Epoch we an interpolate is ](N +1)/2 * τ; ...]
     ///   - the last Epoch we an interpolate is  [..;  T - (N +1)/2 * τ]


### PR DESCRIPTION
- Bad scaling was applied at entry point of the API, SV coordinates are now expressed in km all the time

![Capture](https://github.com/georust/rinex/assets/7270467/27d577a9-b255-4e01-b520-74704adc0e7c)

- Introduce possibitliy to determine such information from radio broadcasted data only

![Capture2](https://github.com/georust/rinex/assets/7270467/778ad066-b3d3-4da1-961c-e0b30a28fd02)

