### PR TITLE
fix: add feature clock to ublox-rnx

### DIFF
--- a/ublox-rnx/Cargo.toml
+++ b/ublox-rnx/Cargo.toml
@@ -22,4 +22,4 @@ serialport = "4.2.0"
 ublox = "0.4.4"
 clap = { version = "4.4.10", features = ["derive", "color"] }
 gnss-rs = { version = "2.1.3", features = ["serde"] }
-rinex = { path = "../rinex", version = "=0.15.7", features = ["serde", "nav", "obs"] }
+rinex = { path = "../rinex", version = "=0.15.7", features = ["serde", "nav", "obs", "clock"] }


### PR DESCRIPTION
So that relevant structs are visible and ublox-rnx compiles