### PR TITLE
Remove malloc in CRINEX header parsing

### DIFF
--- a/rinex/src/doris/mod.rs
+++ b/rinex/src/doris/mod.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::str::FromStr;
+
 use thiserror::Error;
 
 use crate::{
-    domes::{Domes, Error as DomesParsingError, TrackingPoint as DomesTrackingPoint},
+    domes::Error as DomesParsingError,
     observable::Observable,
     prelude::{Duration, Epoch},
 };

--- a/rinex/src/doris/record.rs
+++ b/rinex/src/doris/record.rs
@@ -56,7 +56,7 @@ pub(crate) fn parse_epoch(
 > {
     let mut obs_idx = 0usize;
     let mut epoch = Epoch::default();
-    let mut flag = EpochFlag::default();
+    let flag = EpochFlag::default();
     let mut station = Option::<Station>::None;
     let mut buffer = BTreeMap::<Station, HashMap<Observable, ObservationData>>::new();
 
@@ -69,11 +69,11 @@ pub(crate) fn parse_epoch(
     let stations = &doris.stations;
 
     assert!(
-        stations.len() > 0,
+        !stations.is_empty(),
         "badly formed DORIS RINEX: no stations defined"
     );
     assert!(
-        observables.len() > 0,
+        !observables.is_empty(),
         "badly formed DORIS RINEX: no observables defined"
     );
 
@@ -83,11 +83,11 @@ pub(crate) fn parse_epoch(
                 /* 1st line gives TAI timestamp, flag, clock offset */
                 let line = line.split_at(2).1; // "> "
                 let offset = "YYYY MM DD HH MM SS.NNNNNNNNN  0".len();
-                let (date, rem) = line.split_at(offset);
+                let (date, _rem) = line.split_at(offset);
                 epoch = parse_in_timescale(date, TimeScale::TAI)?;
             },
             _ => {
-                let (id, remainder) = line.split_at(4);
+                let (id, _remainder) = line.split_at(4);
                 //println!("ID : \"{}\" - REMAINDER : \"{}\"", id, remainder); //DBEUG
 
                 if obs_idx == 0 {
@@ -110,7 +110,7 @@ pub(crate) fn parse_epoch(
 
                 // consume this line
                 let mut offset = 5;
-                let mut max_offset = line.len();
+                let max_offset = line.len();
                 while offset < line.len() {
                     let content = &line[offset..std::cmp::min(max_offset, offset + 16)];
                     let obs = &content[..12];
@@ -126,7 +126,7 @@ pub(crate) fn parse_epoch(
                         .parse::<f64>()
                         .unwrap_or_else(|e| panic!("failed to parse observation: {:?}", e));
 
-                    let m1 = if m1.len() > 0 {
+                    let m1 = if !m1.is_empty() {
                         Some(m1.parse::<u8>().unwrap_or_else(|e| {
                             panic!("failed to parse observation m1 flag: {:?}", e)
                         }))
@@ -134,7 +134,7 @@ pub(crate) fn parse_epoch(
                         None
                     };
 
-                    let m2 = if m2.len() > 0 {
+                    let m2 = if !m2.is_empty() {
                         Some(m2.parse::<u8>().unwrap_or_else(|e| {
                             panic!("failed to parse observation m2 flag: {:?}", e)
                         }))
@@ -154,7 +154,7 @@ pub(crate) fn parse_epoch(
                     if let Some(station) = buffer.get_mut(identified_station) {
                         station.insert(observable.clone(), obsdata);
                     } else {
-                        let mut inner =
+                        let inner =
                             HashMap::from_iter([(Observable::default(), obsdata)].into_iter());
                         buffer.insert(identified_station.clone(), inner);
                     }
@@ -236,25 +236,25 @@ impl Preprocessing for Record {
  * Decimates only a given record subset
  */
 #[cfg(feature = "processing")]
-fn decimate_data_subset(record: &mut Record, subset: &Record, target: &TargetItem) {
+fn decimate_data_subset(record: &mut Record, _subset: &Record, target: &TargetItem) {
     match target {
         TargetItem::ClockItem => {
             /*
              * Remove clock fields from self
              * where it should now be missing
              */
-            for (epoch, _) in record.iter_mut() {
+            for (_epoch, _) in record.iter_mut() {
                 //if subset.get(epoch).is_none() {
                 //    // should be missing
                 //    // *clk = None; // now missing
                 //}
             }
         },
-        TargetItem::SvItem(svs) => {
+        TargetItem::SvItem(_svs) => {
             /*
              * Remove SV observations where it should now be missing
              */
-            for (epoch, _) in record.iter_mut() {
+            for (_epoch, _) in record.iter_mut() {
                 //if subset.get(epoch).is_none() {
                 //    // should be missing
                 //    for sv in svs.iter() {
@@ -263,11 +263,11 @@ fn decimate_data_subset(record: &mut Record, subset: &Record, target: &TargetIte
                 //}
             }
         },
-        TargetItem::ObservableItem(obs_list) => {
+        TargetItem::ObservableItem(_obs_list) => {
             /*
              * Remove given observations where it should now be missing
              */
-            for (epoch, _) in record.iter_mut() {
+            for (_epoch, _) in record.iter_mut() {
                 //if subset.get(epoch).is_none() {
                 //    // should be missing
                 //    for (_sv, observables) in vehicles.iter_mut() {
@@ -276,11 +276,11 @@ fn decimate_data_subset(record: &mut Record, subset: &Record, target: &TargetIte
                 //}
             }
         },
-        TargetItem::ConstellationItem(constells_list) => {
+        TargetItem::ConstellationItem(_constells_list) => {
             /*
              * Remove observations for given constellation(s) where it should now be missing
              */
-            for (epoch, _) in record.iter_mut() {
+            for (_epoch, _) in record.iter_mut() {
                 //if subset.get(epoch).is_none() {
                 //    // should be missing
                 //    vehicles.retain(|sv, _| {

--- a/rinex/src/doris/station.rs
+++ b/rinex/src/doris/station.rs
@@ -1,7 +1,5 @@
 //! DORIS Station
-
 use crate::{domes::Domes, doris::Error};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/rinex/src/epoch.rs
+++ b/rinex/src/epoch.rs
@@ -191,11 +191,9 @@ pub(crate) fn parse_in_timescale(content: &str, ts: TimeScale) -> Result<Epoch, 
                     if is_nav {
                         // NAV RINEX : 100ms precision
                         ns *= 100_000_000;
-                    } else {
-                        if nanos.len() != 9 {
-                            // OBS RINEX : 100ns precision
-                            ns *= 100;
-                        }
+                    } else if nanos.len() != 9 {
+                        // OBS RINEX : 100ns precision
+                        ns *= 100;
                     }
                 } else {
                     ss = item

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -232,15 +232,6 @@ macro_rules! parse_float_error {
     };
 }
 
-/*
- * Generates a ParsingError::InvalidIonexGridError(x, y)
- */
-macro_rules! grid_format_error {
-    ($field: expr, $content: expr) => {
-        ParsingError::InvalidIonexGrid(String::from($field), $content.to_string())
-    };
-}
-
 impl Header {
     /// Builds a `Header` from stream reader
     pub fn new(reader: &mut BufferedReader) -> Result<Header, ParsingError> {

--- a/rinex/src/header.rs
+++ b/rinex/src/header.rs
@@ -573,10 +573,8 @@ impl Header {
                     .or(Err(parse_int_error!("SYS / SCALE FACTOR", factor)))?;
 
                 // parse end of line
-                let (_num, remainder) = rem.split_at(3);
-
-                let mut items = remainder.split_ascii_whitespace();
-                for observable_str in items {
+                let (_num, rem) = rem.split_at(3);
+                for observable_str in rem.split_ascii_whitespace() {
                     let observable = Observable::from_str(observable_str)?;
 
                     // latch scaling value

--- a/rinex/src/observable.rs
+++ b/rinex/src/observable.rs
@@ -322,7 +322,7 @@ impl std::str::FromStr for Observable {
                         Ok(Self::Phase(content.to_string()))
                     } else if content.starts_with('C') || content.starts_with('P') {
                         Ok(Self::PseudoRange(content.to_string()))
-                    } else if content.starts_with('S') || content.starts_with("W") {
+                    } else if content.starts_with('S') || content.starts_with('W') {
                         Ok(Self::SSI(content.to_string()))
                     } else if content.starts_with('D') {
                         Ok(Self::Doppler(content.to_string()))

--- a/rinex/src/tests/toolkit/mod.rs
+++ b/rinex/src/tests/toolkit/mod.rs
@@ -7,7 +7,6 @@ use hifitime::TimeSeries;
 /* OBS RINEX dedicated tools */
 mod observation;
 pub use observation::check_observables as obsrinex_check_observables;
-pub use observation::test_crinex;
 pub use observation::test_observation_rinex;
 
 /* DORIS RINEX dedicated tools */

--- a/rinex/src/tests/toolkit/mod.rs
+++ b/rinex/src/tests/toolkit/mod.rs
@@ -7,6 +7,8 @@ use hifitime::TimeSeries;
 /* OBS RINEX dedicated tools */
 mod observation;
 pub use observation::check_observables as obsrinex_check_observables;
+pub use observation::test_crinex;
+pub use observation::test_observation_rinex;
 
 /* DORIS RINEX dedicated tools */
 mod doris;
@@ -621,82 +623,4 @@ pub fn test_ionex(dut: &Rinex, version: &str, constellation: Option<&str>) {
         dut.header.clock.is_none(),
         "should not contain specific CLOCK fields"
     );
-}
-
-/*
- * Any parsed OBSERVATION RINEX should go through this test
- */
-pub fn test_observation_rinex(
-    dut: &Rinex,
-    version: &str,
-    constellation: Option<&str>,
-    gnss_csv: &str,
-    sv_csv: &str,
-    observ_csv: &str,
-    time_of_first_obs: Option<&str>,
-    time_of_last_obs: Option<&str>,
-    time_frame: TestTimeFrame,
-    //observ_gnss_json: &str,
-) {
-    test_rinex(dut, version, constellation);
-    assert!(
-        dut.is_observation_rinex(),
-        "should be declared as OBS RINEX"
-    );
-
-    assert!(
-        dut.record.as_obs().is_some(),
-        "observation record unwrapping"
-    );
-    test_sv_csv(dut, sv_csv);
-    test_gnss_csv(dut, gnss_csv);
-    test_time_frame(dut, time_frame);
-    test_observables_csv(dut, observ_csv);
-    /*
-     * Specific header field testing
-     */
-    assert!(
-        dut.header.obs.is_some(),
-        "missing observation specific header fields"
-    );
-    assert!(
-        dut.header.meteo.is_none(),
-        "should not contain specific METEO fields"
-    );
-    assert!(
-        dut.header.ionex.is_none(),
-        "should not contain specific IONEX fields"
-    );
-    assert!(
-        dut.header.clock.is_none(),
-        "should not contain specific CLOCK fields"
-    );
-
-    let header = dut.header.obs.as_ref().unwrap();
-    //for (constell, observables) in observables {
-    //    assert!(header_obs.codes.get(&constell).is_some(), "observation rinex specific header missing observables for constellation {}", constell);
-    //    let values = header_obs.codes.get(&constell).unwrap();
-    //    for o in &observables {
-    //        assert!(values.contains(&o), "observation rinex specific {} header is missing {} observable", constell, o);
-    //    }
-    //    for o in values {
-    //        assert!(values.contains(&o), "observation rinex specific {} header should not contain {} observable", constell, o);
-    //    }
-    //}
-    if let Some(time_of_first_obs) = time_of_first_obs {
-        assert_eq!(
-            Some(Epoch::from_str(time_of_first_obs).unwrap()),
-            header.time_of_first_obs,
-            "obs header is missing time of first obs \"{}\"",
-            time_of_first_obs
-        );
-    }
-    if let Some(time_of_last_obs) = time_of_last_obs {
-        assert_eq!(
-            Some(Epoch::from_str(time_of_last_obs).unwrap()),
-            header.time_of_last_obs,
-            "obs header is missing time of last obs \"{}\"",
-            time_of_last_obs
-        );
-    }
 }

--- a/rinex/src/tests/toolkit/observation.rs
+++ b/rinex/src/tests/toolkit/observation.rs
@@ -1,5 +1,8 @@
 // use crate::observation::Record as ObsRecord;
-use crate::prelude::{Constellation, Observable, Rinex};
+use crate::prelude::{Constellation, Epoch, Observable, Rinex};
+use crate::tests::toolkit::{
+    test_gnss_csv, test_observables_csv, test_rinex, test_sv_csv, test_time_frame, TestTimeFrame,
+};
 use std::str::FromStr;
 
 /*
@@ -49,5 +52,83 @@ pub fn check_observables(rnx: &Rinex, constellation: Constellation, observables:
         _ => {
             panic!("empty observation specific header fields");
         },
+    }
+}
+
+/*
+ * Any parsed OBSERVATION RINEX should go through this test
+ */
+pub fn test_observation_rinex(
+    dut: &Rinex,
+    version: &str,
+    constellation: Option<&str>,
+    gnss_csv: &str,
+    sv_csv: &str,
+    observ_csv: &str,
+    time_of_first_obs: Option<&str>,
+    time_of_last_obs: Option<&str>,
+    time_frame: TestTimeFrame,
+    //observ_gnss_json: &str,
+) {
+    test_rinex(dut, version, constellation);
+    assert!(
+        dut.is_observation_rinex(),
+        "should be declared as OBS RINEX"
+    );
+
+    assert!(
+        dut.record.as_obs().is_some(),
+        "observation record unwrapping"
+    );
+    test_sv_csv(dut, sv_csv);
+    test_gnss_csv(dut, gnss_csv);
+    test_time_frame(dut, time_frame);
+    test_observables_csv(dut, observ_csv);
+    /*
+     * Specific header field testing
+     */
+    assert!(
+        dut.header.obs.is_some(),
+        "missing observation specific header fields"
+    );
+    assert!(
+        dut.header.meteo.is_none(),
+        "should not contain specific METEO fields"
+    );
+    assert!(
+        dut.header.ionex.is_none(),
+        "should not contain specific IONEX fields"
+    );
+    assert!(
+        dut.header.clock.is_none(),
+        "should not contain specific CLOCK fields"
+    );
+
+    let header = dut.header.obs.as_ref().unwrap();
+    //for (constell, observables) in observables {
+    //    assert!(header_obs.codes.get(&constell).is_some(), "observation rinex specific header missing observables for constellation {}", constell);
+    //    let values = header_obs.codes.get(&constell).unwrap();
+    //    for o in &observables {
+    //        assert!(values.contains(&o), "observation rinex specific {} header is missing {} observable", constell, o);
+    //    }
+    //    for o in values {
+    //        assert!(values.contains(&o), "observation rinex specific {} header should not contain {} observable", constell, o);
+    //    }
+    //}
+    if let Some(time_of_first_obs) = time_of_first_obs {
+        assert_eq!(
+            Some(Epoch::from_str(time_of_first_obs).unwrap()),
+            header.time_of_first_obs,
+            "obs header is missing time of first obs \"{}\"",
+            time_of_first_obs
+        );
+    }
+    if let Some(time_of_last_obs) = time_of_last_obs {
+        assert_eq!(
+            Some(Epoch::from_str(time_of_last_obs).unwrap()),
+            header.time_of_last_obs,
+            "obs header is missing time of last obs \"{}\"",
+            time_of_last_obs
+        );
     }
 }


### PR DESCRIPTION
- Removes one memory allocation in the parsing process (slight improvement)
- Run clippy