### PR TITLE
Switch to ANISE for ECEF (IAU Earth) computation

### DIFF
--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -7,7 +7,12 @@ description = "Command line tool parse and analyze RINEX data"
 homepage = "https://github.com/georust/rinex"
 repository = "https://github.com/georust/rinex"
 keywords = ["rinex", "gps", "glonass", "galileo", "timing"]
-categories = ["science", "science::geo", "command-line-interface", "command-line-utilities"]
+categories = [
+    "science",
+    "science::geo",
+    "command-line-interface",
+    "command-line-utilities",
+]
 edition = "2021"
 readme = "README.md"
 rust-version = "1.64"
@@ -30,20 +35,31 @@ map_3d = "0.1.5"
 colorous = "1.0"
 horrorshow = "0.8"
 clap = { version = "4.4.13", features = ["derive", "color"] }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = ["serde", "std"] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = [
+    "serde",
+    "std",
+] }
+gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = [
+    "serde",
+] }
 rinex = { path = "../rinex", version = "=0.16.1", features = ["full"] }
 plotly = { git = "https://github.com/plotly/plotly.rs", branch = "main" }
-rinex-qc = { path = "../rinex-qc", version = "=0.1.14", features = ["serde"] } 
-sp3 = { path = "../sp3", version = "=1.0.8",  features = ["serde", "flate2"] }
+rinex-qc = { path = "../rinex-qc", version = "=0.1.14", features = ["serde"] }
+sp3 = { path = "../sp3", version = "=1.0.8", features = ["serde", "flate2"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # solver
 # gnss-rtk = { version = "0.4.5", features = ["serde"] }
 # gnss-rtk = { path = "../../rtk-rs/gnss-rtk", features = ["serde"] }
-gnss-rtk = { git = "https://github.com/rtk-rs/gnss-rtk", branch = "main", features = ["serde"] }
+# gnss-rtk = { git = "https://github.com/ChristopherRabotin/gnss-rtk", branch = "main", features = [
+#     "serde",
+# ] }
+gnss-rtk = { path = "../../gnss-rtk", features = ["serde"] }
 
 # cggtts
 # cggtts = { version = "4.1.4", features = ["serde", "scheduler"] }
 # cggtts = { path = "../../cggtts/cggtts", features = ["serde", "scheduler"] }
-cggtts = { git = "https://github.com/gwbres/cggtts", branch = "dev", features = ["serde", "scheduler"] }
+cggtts = { git = "https://github.com/gwbres/cggtts", branch = "dev", features = [
+    "serde",
+    "scheduler",
+] }

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -48,6 +48,8 @@ rinex-qc = { path = "../rinex-qc", version = "=0.1.14", features = ["serde"] }
 sp3 = { path = "../sp3", version = "=1.0.8", features = ["serde", "flate2"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
+anise = "0.4.0"
+
 # solver
 # gnss-rtk = { version = "0.4.5", features = ["serde"] }
 # gnss-rtk = { path = "../../rtk-rs/gnss-rtk", features = ["serde"] }

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 # solver
 # gnss-rtk = { version = "0.4.5", features = ["serde"] }
 # gnss-rtk = { path = "../../rtk-rs/gnss-rtk", features = ["serde"] }
-# gnss-rtk = { git = "https://github.com/ChristopherRabotin/gnss-rtk", branch = "main", features = [
+# gnss-rtk = { git = "https://github.com/ChristopherRabotin/gnss-rtk", branch = "deps/nyx-2.0.0-beta", features = [
 #     "serde",
 # ] }
 # Using your fork
@@ -64,3 +64,4 @@ cggtts = { git = "https://github.com/gwbres/cggtts", branch = "dev", features = 
     "serde",
     "scheduler",
 ] }
+bytes = "1.6.0"

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -54,6 +54,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 # gnss-rtk = { git = "https://github.com/ChristopherRabotin/gnss-rtk", branch = "main", features = [
 #     "serde",
 # ] }
+# Using your fork
 gnss-rtk = { path = "../../gnss-rtk", features = ["serde"] }
 
 # cggtts

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -35,7 +35,7 @@ map_3d = "0.1.5"
 colorous = "1.0"
 horrorshow = "0.8"
 clap = { version = "4.4.13", features = ["derive", "color"] }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = [
+hifitime = { version = "4.0.0-alpha", features = [
     "serde",
     "std",
 ] }

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -35,35 +35,21 @@ map_3d = "0.1.5"
 colorous = "1.0"
 horrorshow = "0.8"
 clap = { version = "4.4.13", features = ["derive", "color"] }
-hifitime = { version = "4.0.0-alpha", features = [
-    "serde",
-    "std",
-] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = [
-    "serde",
-] }
-rinex = { path = "../rinex", version = "=0.16.1", features = ["full"] }
 plotly = { git = "https://github.com/plotly/plotly.rs", branch = "main" }
+
+anise = "0.4.0"
+gnss-rs = { version = "2.2.0", features = ["serde"] }
+hifitime = { version = "4.0.0-alpha", features = ["serde", "std"] }
+
+rinex = { path = "../rinex", version = "=0.16.1", features = ["full"] }
 rinex-qc = { path = "../rinex-qc", version = "=0.1.14", features = ["serde"] }
 sp3 = { path = "../sp3", version = "=1.0.8", features = ["serde", "flate2"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
-anise = "0.4.0"
-
-# solver
 # gnss-rtk = { version = "0.4.5", features = ["serde"] }
 # gnss-rtk = { path = "../../rtk-rs/gnss-rtk", features = ["serde"] }
-# gnss-rtk = { git = "https://github.com/ChristopherRabotin/gnss-rtk", branch = "deps/nyx-2.0.0-beta", features = [
-#     "serde",
-# ] }
-# Using your fork
-gnss-rtk = { path = "../../gnss-rtk", features = ["serde"] }
+gnss-rtk = { git = "https://github.com/rtk-rs/gnss-rtk", branch = "main", features = ["serde"] }
 
-# cggtts
 # cggtts = { version = "4.1.4", features = ["serde", "scheduler"] }
 # cggtts = { path = "../../cggtts/cggtts", features = ["serde", "scheduler"] }
-cggtts = { git = "https://github.com/gwbres/cggtts", branch = "dev", features = [
-    "serde",
-    "scheduler",
-] }
-bytes = "1.6.0"
+cggtts = { git = "https://github.com/gwbres/cggtts", branch = "main", features = ["serde", "scheduler"]}

--- a/rinex-cli/src/graph/mod.rs
+++ b/rinex-cli/src/graph/mod.rs
@@ -300,19 +300,13 @@ pub fn build_timedomain_2y_plot(title: &str, y1_title: &str, y2_title: &str) -> 
  */
 pub fn build_default_polar_plot(title: &str) -> Plot {
     let layout = Layout::new()
-        .title(Title::new(title))
+        .title(title)
         .x_axis(
-            Axis::new()
-                .title(Title::new("Latitude [°]").side(Side::Top))
-                .zero_line(true), //.show_tick_labels(show_tick_labels)
-                                  //.dtick(dx_tick)
-                                  //.tick_format(tick_fmt)
+            Axis::new().title("Latitude [°]").zero_line(true), //.show_tick_labels(show_tick_labels)
+                                                               //.dtick(dx_tick)
+                                                               //.tick_format(tick_fmt)
         )
-        .y_axis(
-            Axis::new()
-                .title(Title::new("Longitude [°]"))
-                .zero_line(true),
-        )
+        .y_axis(Axis::new().title("Longitude [°]").zero_line(true))
         .show_legend(true)
         .auto_size(true);
     let mut p = Plot::new();
@@ -334,7 +328,7 @@ pub fn build_world_map(
 ) -> Plot {
     let mut p = Plot::new();
     let layout = Layout::new()
-        .title(Title::new(title).font(Font::default()))
+        .title(title)
         .drag_mode(DragMode::Zoom)
         .margin(Margin::new().top(0).left(0).bottom(0).right(0))
         .show_legend(show_legend)
@@ -365,20 +359,16 @@ fn build_plot(
     x_tick_fmt: &str,
 ) -> Plot {
     let layout = Layout::new()
-        .title(Title::new(title).font(title_font))
+        .title(title)
         .x_axis(
             Axis::new()
-                .title(Title::new(x_axis_title).side(title_side))
+                .title(x_axis_title)
                 .zero_line(zero_line.0)
                 .show_tick_labels(show_xtick_labels)
                 .dtick(dx_tick)
                 .tick_format(x_tick_fmt),
         )
-        .y_axis(
-            Axis::new()
-                .title(Title::new(y_axis_title))
-                .zero_line(zero_line.0),
-        )
+        .y_axis(Axis::new().title(y_axis_title).zero_line(zero_line.0))
         .show_legend(show_legend)
         .auto_size(auto_size);
     let mut p = Plot::new();
@@ -401,23 +391,19 @@ fn build_plot_2y(
     xtick_fmt: &str,
 ) -> Plot {
     let layout = Layout::new()
-        .title(Title::new(title).font(title_font))
+        .title(title)
         .x_axis(
             Axis::new()
-                .title(Title::new(x_title).side(title_side))
+                .title(x_title)
                 .zero_line(zero_line.0)
                 .show_tick_labels(show_xtick_labels)
                 .dtick(dx_tick)
                 .tick_format(xtick_fmt),
         )
-        .y_axis(
-            Axis::new()
-                .title(Title::new(y1_title))
-                .zero_line(zero_line.1),
-        )
+        .y_axis(Axis::new().title(y1_title).zero_line(zero_line.1))
         .y_axis2(
             Axis::new()
-                .title(Title::new(y2_title))
+                .title(y2_title)
                 .overlaying("y")
                 .side(AxisSide::Right)
                 .zero_line(zero_line.1),
@@ -441,23 +427,15 @@ fn build_3d_plot(
     auto_size: bool,
 ) -> Plot {
     let layout = Layout::new()
-        .title(Title::new(title).font(title_font))
+        .title(title)
         .x_axis(
             Axis::new()
-                .title(Title::new(x_title).side(title_side))
+                .title(x_title)
                 .zero_line(zero_line.0)
                 .show_tick_labels(false),
         )
-        .y_axis(
-            Axis::new()
-                .title(Title::new(y_title))
-                .zero_line(zero_line.1),
-        )
-        .z_axis(
-            Axis::new()
-                .title(Title::new(z_title))
-                .zero_line(zero_line.2),
-        )
+        .y_axis(Axis::new().title(y_title).zero_line(zero_line.1))
+        .z_axis(Axis::new().title(z_title).zero_line(zero_line.2))
         .show_legend(show_legend)
         .auto_size(auto_size);
     let mut p = Plot::new();

--- a/rinex-cli/src/positioning/orbit/mod.rs
+++ b/rinex-cli/src/positioning/orbit/mod.rs
@@ -2,29 +2,28 @@ use crate::cli::Context;
 use gnss_rtk::prelude::{Epoch, InterpolationResult, SV};
 
 // would you mind adapting the includes in ::sp3 ?
-// mod sp3;
-// use sp3::Orbit as SP3Orbit;
+mod sp3;
+use sp3::Orbit as SP3Orbit;
 
 mod nav;
 use nav::Orbit as NAVOrbit;
 
 pub enum Orbit<'a> {
-    // SP3(SP3Orbit<'a>),
+    SP3(SP3Orbit<'a>),
     NAV(NAVOrbit<'a>),
 }
 
 impl<'a> Orbit<'a> {
     pub fn from_ctx(ctx: &'a Context, order: usize) -> Self {
         if ctx.data.has_sp3() {
-            panic!("please, patch the includes in ::sp3 option");
-            // Self::SP3(SP3Orbit::from_ctx(ctx, order))
+            Self::SP3(SP3Orbit::from_ctx(ctx, order))
         } else {
             Self::NAV(NAVOrbit::from_ctx(ctx))
         }
     }
     pub fn next_at(&mut self, t: Epoch, sv: SV) -> Option<InterpolationResult> {
         match self {
-            // Self::SP3(orbit) => orbit.next_at(t, sv),
+            Self::SP3(orbit) => orbit.next_at(t, sv),
             Self::NAV(orbit) => orbit.next_at(t, sv),
         }
     }

--- a/rinex-cli/src/positioning/orbit/mod.rs
+++ b/rinex-cli/src/positioning/orbit/mod.rs
@@ -1,28 +1,30 @@
 use crate::cli::Context;
 use gnss_rtk::prelude::{Epoch, InterpolationResult, SV};
 
-mod sp3;
-use sp3::Orbit as SP3Orbit;
+// would you mind adapting the includes in ::sp3 ?
+// mod sp3;
+// use sp3::Orbit as SP3Orbit;
 
 mod nav;
 use nav::Orbit as NAVOrbit;
 
 pub enum Orbit<'a> {
-    SP3(SP3Orbit<'a>),
+    // SP3(SP3Orbit<'a>),
     NAV(NAVOrbit<'a>),
 }
 
 impl<'a> Orbit<'a> {
     pub fn from_ctx(ctx: &'a Context, order: usize) -> Self {
         if ctx.data.has_sp3() {
-            Self::SP3(SP3Orbit::from_ctx(ctx, order))
+            panic!("please, patch the includes in ::sp3 option");
+            // Self::SP3(SP3Orbit::from_ctx(ctx, order))
         } else {
             Self::NAV(NAVOrbit::from_ctx(ctx))
         }
     }
     pub fn next_at(&mut self, t: Epoch, sv: SV) -> Option<InterpolationResult> {
         match self {
-            Self::SP3(orbit) => orbit.next_at(t, sv),
+            // Self::SP3(orbit) => orbit.next_at(t, sv),
             Self::NAV(orbit) => orbit.next_at(t, sv),
         }
     }

--- a/rinex-cli/src/positioning/orbit/sp3.rs
+++ b/rinex-cli/src/positioning/orbit/sp3.rs
@@ -6,9 +6,10 @@ use gnss_rtk::prelude::{
     Almanac, Epoch, InterpolationResult as RTKInterpolationResult, TimeScale, Vector3, EARTH_J2000,
     SPK, SUN_J2000, SV,
 };
-use gnss_rtk::AstroData;
 
 use rinex::carrier::Carrier;
+
+use anise::almanac::metaload::MetaFile;
 
 #[derive(Debug)]
 struct Buffer {
@@ -70,9 +71,13 @@ pub struct Orbit<'a> {
 
 impl<'a> Orbit<'a> {
     pub fn from_ctx(ctx: &'a Context, order: usize) -> Self {
-        let de440s = AstroData::get("de440s.bsp").unwrap();
-        let de440s_bytes = Bytes::copy_from_slice(de440s.data.as_ref());
-        let almanac = Almanac::from_spk(SPK::parse(de440s_bytes).unwrap()).unwrap();
+        let meta = MetaFile {
+            uri: "http://public-data.nyxspace.com/anise/v0.4/de440s.bsp".to_string(),
+            crc32: Some(3072159656), // Specifying the CRC allows only downloading the data once.
+        };
+        let almanac = Almanac::default()
+            .load_from_metafile(meta)
+            .unwrap_or_else(|e| panic!("failed to build Almanac: {}", e));
 
         let sp3 = ctx.data.sp3().unwrap();
         Self {

--- a/rinex-cli/src/positioning/orbit/sp3.rs
+++ b/rinex-cli/src/positioning/orbit/sp3.rs
@@ -1,10 +1,12 @@
 use crate::{cli::Context, positioning::BufferTrait};
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use gnss_rtk::prelude::{
-    Arc, Bodies, Cosm, Epoch, Frame, InterpolationResult as RTKInterpolationResult, LightTimeCalc,
-    TimeScale, Vector3, SV,
+    Almanac, Epoch, InterpolationResult as RTKInterpolationResult, TimeScale, Vector3, EARTH_J2000,
+    SPK, SUN_J2000, SV,
 };
+use gnss_rtk::AstroData;
 
 use rinex::carrier::Carrier;
 
@@ -49,13 +51,13 @@ impl BufferTrait<(f64, f64, f64)> for Buffer {
 /*
  * Evaluates Sun / Earth vector in meters ECEF at "t"
  */
-fn sun_unit_vector(ref_frame: &Frame, cosmic: &Arc<Cosm>, t: Epoch) -> Vector3<f64> {
-    let sun_body = Bodies::Sun; // This only works in the solar system..
-    let orbit = cosmic.celestial_state(sun_body.ephem_path(), t, *ref_frame, LightTimeCalc::None);
+fn sun_unit_vector(almanac: &Almanac, t: Epoch) -> Vector3<f64> {
+    let earth2sun = almanac.transform(EARTH_J2000, SUN_J2000, t, None).unwrap();
+
     Vector3::new(
-        orbit.x_km * 1000.0,
-        orbit.y_km * 1000.0,
-        orbit.z_km * 1000.0,
+        earth2sun.radius_km.x * 1000.0,
+        earth2sun.radius_km.y * 1000.0,
+        earth2sun.radius_km.z * 1000.0,
     )
 }
 
@@ -68,9 +70,11 @@ pub struct Orbit<'a> {
 
 impl<'a> Orbit<'a> {
     pub fn from_ctx(ctx: &'a Context, order: usize) -> Self {
-        let cosmic = Cosm::de438();
+        let de440s = AstroData::get("de440s.bsp").unwrap();
+        let de440s_bytes = Bytes::copy_from_slice(de440s.data.as_ref());
+        let almanac = Almanac::from_spk(SPK::parse(de440s_bytes).unwrap()).unwrap();
+
         let sp3 = ctx.data.sp3().unwrap();
-        let earth_frame = cosmic.frame("EME2000"); // this only works on planet Earth..
         Self {
             order,
             epochs: 0,
@@ -85,7 +89,7 @@ impl<'a> Orbit<'a> {
                         let k = -r_sat
                             / (r_sat[0].powi(2) + r_sat[1].powi(2) + r_sat[3].powi(2)).sqrt();
 
-                        let r_sun = sun_unit_vector(&earth_frame, &cosmic, t);
+                        let r_sun = sun_unit_vector(&almanac, t);
                         let norm = ((r_sun[0] - r_sat[0]).powi(2)
                             + (r_sun[1] - r_sat[1]).powi(2)
                             + (r_sun[2] - r_sat[2]).powi(2))

--- a/rinex-cli/src/positioning/orbit/sp3.rs
+++ b/rinex-cli/src/positioning/orbit/sp3.rs
@@ -1,7 +1,6 @@
 use crate::{cli::Context, positioning::BufferTrait};
 use std::collections::HashMap;
 
-use bytes::Bytes;
 use gnss_rtk::prelude::{
     Almanac, Epoch, InterpolationResult as RTKInterpolationResult, TimeScale, Vector3, EARTH_J2000,
     SPK, SUN_J2000, SV,

--- a/rinex-qc/Cargo.toml
+++ b/rinex-qc/Cargo.toml
@@ -31,8 +31,7 @@ rinex-qc-traits = { path = "../qc-traits", version = "=0.1.1" }
 rinex = { path = "../rinex", version = "=0.16.1", features = ["full"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
-# gnss-rs = { version = "2.1.3", features = ["serde"] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+gnss-rs = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/rinex-qc/Cargo.toml
+++ b/rinex-qc/Cargo.toml
@@ -19,16 +19,17 @@ all-features = true
 rustdoc-args = ["--cfg", "docrs", "--generate-link-to-definition"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master" }
 strum = "0.26"
-strum_macros = "0.26"
+statrs = "0.16"
 horrorshow = "0.8"
 itertools = "0.13.0"
-statrs = "0.16"
+strum_macros = "0.26"
+hifitime = "4.0.0-alpha"
+
 sp3 = { path = "../sp3", version = "=1.0.8", features = ["serde"] }
 rinex-qc-traits = { path = "../qc-traits", version = "=0.1.1" }
 rinex = { path = "../rinex", version = "=0.16.1", features = ["full"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 # gnss-rs = { version = "2.1.3", features = ["serde"] }
 gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -49,11 +49,11 @@ processing = []
 
 # Unlock Quality Check (QC) methods and traits.
 # Allows to generate complete QC reports for RINEX or entire contexts.
-qc = ["rinex-qc-traits", "horrorshow"] 
+qc = ["rinex-qc-traits", "horrorshow"]
 
 # Unlock SP3 support to be able to integrate SP3 precise orbits
 # into a complete Context.
-sp3 = ["dep:sp3", "walkdir"] 
+sp3 = ["dep:sp3", "walkdir"]
 
 # Unlock all features, all at once
 full = [
@@ -87,7 +87,7 @@ num-derive = "0.4"
 num-traits = "0.2.15"
 regex = "1"
 thiserror = "1"
-bitflags = { version = "2.3", features = ["serde"] } 
+bitflags = { version = "2.3", features = ["serde"] }
 lazy_static = "1.4"
 map_3d = "0.1.5"
 strum = "0.26"
@@ -96,12 +96,22 @@ num-integer = "0.1.44"
 itertools = "0.13.0"
 geo = { version = "0.28", optional = true }
 wkt = { version = "0.10.0", default-features = false, optional = true }
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-flate2 = { version = "1.0.24", optional = true, default-features = false, features = ["zlib"] }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = ["serde", "std"] }
+serde = { version = "1.0", optional = true, default-features = false, features = [
+    "derive",
+] }
+flate2 = { version = "1.0.24", optional = true, default-features = false, features = [
+    "zlib",
+] }
+hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = [
+    "serde",
+    "std",
+] }
 horrorshow = { version = "0.8", optional = true }
 nalgebra = { version = "0.32.3" }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = [
+    "serde",
+] }
+anise = { git = "https://github.com/nyx-space/anise.git", branch = "master" }
 
 # RINEX QC dedicated traits
 rinex-qc-traits = { path = "../qc-traits", version = "=0.1.1", optional = true }

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -102,7 +102,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 flate2 = { version = "1.0.24", optional = true, default-features = false, features = [
     "zlib",
 ] }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master", features = [
+hifitime = { version = "4.0.0-alpha", features = [
     "serde",
     "std",
 ] }

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -108,9 +108,7 @@ hifitime = { version = "4.0.0-alpha", features = [
 ] }
 horrorshow = { version = "0.8", optional = true }
 nalgebra = { version = "0.32.3" }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = [
-    "serde",
-] }
+gnss-rs = { version = "2.2.0", features = ["serde"] }
 anise = { git = "https://github.com/nyx-space/anise.git", branch = "master" }
 
 # RINEX QC dedicated traits

--- a/rinex/src/navigation/ephemeris.rs
+++ b/rinex/src/navigation/ephemeris.rs
@@ -5,7 +5,7 @@ use crate::{constants, epoch, prelude::*, version::Version};
 use anise::almanac::Almanac;
 use anise::constants::frames::{EARTH_J2000, IAU_EARTH_FRAME};
 use anise::prelude::Orbit;
-use nalgebra::{Rotation, Rotation3, Vector3};
+use nalgebra::Vector3;
 use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
@@ -262,7 +262,7 @@ impl Ephemeris {
      */
     pub(crate) fn ephemeris_helper(&self, sv: SV, t: Epoch) -> Option<EphemerisHelper> {
         // const
-        let gm = Constants::gm(sv);
+        let gm_m3_s2 = Constants::gm(sv);
         let omega = Constants::omega(sv);
         let dtr_f = Constants::dtr_f(sv);
         let mut helper = EphemerisHelper {
@@ -284,7 +284,7 @@ impl Ephemeris {
         let perturbations = self.perturbations()?;
 
         // m_k, e_k, v_k calculation
-        let n0 = (gm / kepler.a.powi(3)).sqrt();
+        let n0 = (gm_m3_s2 / kepler.a.powi(3)).sqrt();
         let n = n0 + perturbations.dn;
         let m_k = kepler.m_0 + n * helper.t_k;
         // Iterative calculation of e_k
@@ -357,7 +357,7 @@ impl Ephemeris {
                 helper.u_k,
                 v_k,
                 t,
-                EARTH_J2000,
+                EARTH_J2000.with_mu_km3_s2(gm_m3_s2 * 1e-9),
             )
             .unwrap(),
         );

--- a/rinex/src/navigation/ephemeris.rs
+++ b/rinex/src/navigation/ephemeris.rs
@@ -2,8 +2,10 @@ use super::{orbits::closest_nav_standards, NavMsgType, OrbitItem};
 use crate::constants::Constants;
 use crate::{constants, epoch, prelude::*, version::Version};
 
-use log::warn;
-use nalgebra::{self as na, Rotation, Rotation3, Vector3, Vector4};
+use anise::almanac::Almanac;
+use anise::constants::frames::{EARTH_J2000, IAU_EARTH_FRAME};
+use anise::prelude::Orbit;
+use nalgebra::{Rotation, Rotation3, Vector3};
 use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
@@ -62,172 +64,25 @@ pub struct EphemerisHelper {
     pub dtr: f64,
     /// First Derivative of Relativistic Effect Correction
     pub fd_dtr: f64,
+    pub orbit: Option<Orbit>,
 }
 
 impl EphemerisHelper {
-    pub(crate) fn meo_orbit_to_ecef_rotation_matrix(&self) -> Rotation<f64, 3> {
-        // Positive angles mean counterclockwise rotation
-        let rotation_x = Rotation3::from_axis_angle(&Vector3::x_axis(), self.i_k);
-        let rotation_z = Rotation3::from_axis_angle(&Vector3::z_axis(), self.omega_k);
-        rotation_z * rotation_x
-    }
-
-    pub(crate) fn geo_orbit_to_ecef_rotation_matrix(&self) -> Rotation<f64, 3> {
-        let rotation_x = Rotation::from_axis_angle(&Vector3::x_axis(), 5.0f64.to_radians());
-        let rotation_z =
-            Rotation::from_axis_angle(&Vector3::z_axis(), -constants::Omega::BDS * self.t_k);
-        rotation_z * rotation_x
-    }
-
-    pub(crate) fn orbit_velocity(&self) -> (f64, f64) {
-        let (sin_u_k, cos_u_k) = self.u_k.sin_cos();
-        let fd_x = self.fd_r_k * cos_u_k - self.r_k * self.fd_u_k * sin_u_k;
-        let fd_y = self.fd_r_k * sin_u_k + self.r_k * self.fd_u_k * cos_u_k;
-        (fd_x, fd_y)
-    }
-
-    /// Calculate ecef position of MEO/IGSO sv
-    /// work for GPS,Galieo,BeiDou(MEO/IGSO)
-    pub(crate) fn ecef_position(&self) -> Vector3<f64> {
-        let orbit_xyz = Vector3::new(self.orbit_position.0, self.orbit_position.1, 0.0);
-        let ecef_xyz = self.meo_orbit_to_ecef_rotation_matrix() * orbit_xyz;
-        ecef_xyz
-    }
-
-    /// Calculate ecef velocity of MEO/IGSO sv
-    /// work for GPS,Galieo,BeiDou(MEO/IGSO)
-    pub(crate) fn ecef_velocity(&self) -> Vector3<f64> {
-        let (x, y) = self.orbit_position;
-        let (sin_omega_k, cos_omega_k) = self.omega_k.sin_cos();
-        let (sin_i_k, cos_i_k) = self.i_k.sin_cos();
-        // First Derivative of orbit position
-        let (fd_x, fd_y) = self.orbit_velocity();
-        // First Derivative of rotation Matrix
-        let mut fd_R = na::SMatrix::<f64, 3, 4>::zeros();
-        fd_R[(0, 0)] = cos_omega_k;
-        fd_R[(0, 1)] = -sin_omega_k * cos_i_k;
-        fd_R[(0, 2)] = -(x * sin_omega_k + y * cos_omega_k * cos_i_k);
-        fd_R[(0, 3)] = y * sin_omega_k * sin_i_k;
-        fd_R[(1, 0)] = sin_omega_k;
-        fd_R[(1, 1)] = cos_omega_k * cos_i_k;
-        fd_R[(1, 2)] = x * cos_omega_k - y * sin_omega_k * cos_i_k;
-        fd_R[(1, 3)] = y * cos_omega_k * sin_i_k;
-        fd_R[(2, 1)] = sin_i_k;
-        fd_R[(2, 3)] = y * cos_i_k;
-
-        let rhs = Vector4::new(fd_x, fd_y, self.fd_omega_k, self.fd_i_k);
-        let vel = fd_R * rhs;
-        vel
-    }
-
     /// Calculate ecef position and velocity of MEO/IGSO sv
     /// # Return
     /// ( Position(x,y,z),Velecity(x,y,z) )
-    pub(crate) fn ecef_pv(&self) -> (Vector3<f64>, Vector3<f64>) {
-        (self.ecef_position(), self.ecef_velocity())
-    }
-
-    /// Calculate ecef position of GEO sv
-    pub(crate) fn beidou_geo_ecef_position(&self) -> Vector3<f64> {
-        let orbit_xyz = Vector3::new(self.orbit_position.0, self.orbit_position.1, 0.0);
-        let rotation1 = self.meo_orbit_to_ecef_rotation_matrix();
-        let rotation2 = self.geo_orbit_to_ecef_rotation_matrix();
-        let ecef_xyz = rotation2 * rotation1 * orbit_xyz;
-        ecef_xyz
-    }
-
-    /// Calculate ecef velocity of GEO sv
-    pub(crate) fn beidou_geo_ecef_velocity(&self) -> Vector3<f64> {
-        let (x, y) = self.orbit_position;
-        let (sin_omega_k, cos_omega_k) = self.omega_k.sin_cos();
-        let (sin_i_k, cos_i_k) = self.i_k.sin_cos();
-        let (fd_x, fd_y) = self.orbit_velocity();
-        let fd_xgk = -y * self.fd_omega_k - fd_y * cos_i_k * sin_omega_k + fd_x * cos_omega_k;
-        let fd_ygk = x * self.fd_omega_k + fd_y * cos_i_k * cos_omega_k + fd_x * sin_omega_k;
-        let fd_zgk = fd_y * sin_i_k + y * self.fd_i_k * cos_i_k;
-
-        let rx = Rotation3::from_axis_angle(&Vector3::x_axis(), 5.0);
-        let rz = Rotation3::from_axis_angle(&Vector3::z_axis(), -constants::Omega::BDS * self.t_k);
-        let (sin_omega_tk, cos_omega_tk) = (constants::Omega::BDS * self.t_k).sin_cos();
-        let fd_rz = self.fd_omega_k
-            * na::Matrix3::new(
-                -sin_omega_tk,
-                cos_omega_tk,
-                0.0,
-                -cos_omega_tk,
-                -sin_omega_tk,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            );
-        let pos = self.beidou_geo_ecef_position();
-        let fd_pos = Vector3::new(fd_xgk, fd_ygk, fd_zgk);
-        let vel = fd_rz * rx * pos + rz * rx * fd_pos;
-        vel
-    }
-
-    /// Calculate ecef position and velocity of BeiDou GEO sv
-    /// # Return
-    /// ( Position(x,y,z),Velecity(x,y,z) )
-    pub(crate) fn beidou_geo_ecef_pv(&self) -> (Vector3<f64>, Vector3<f64>) {
-        let (x, y) = self.orbit_position;
-        let (sin_omega_k, cos_omega_k) = self.omega_k.sin_cos();
-        let (sin_i_k, cos_i_k) = self.i_k.sin_cos();
-        let (fd_x, fd_y) = self.orbit_velocity();
-        let fd_xgk = -y * self.fd_omega_k - fd_y * cos_i_k * sin_omega_k + fd_x * cos_omega_k;
-        let fd_ygk = x * self.fd_omega_k + fd_y * cos_i_k * cos_omega_k + fd_x * sin_omega_k;
-        let fd_zgk = fd_y * sin_i_k + y * self.fd_i_k * cos_i_k;
-
-        let rx = Rotation3::from_axis_angle(&Vector3::x_axis(), 5.0);
-        let rz = Rotation3::from_axis_angle(&Vector3::z_axis(), -constants::Omega::BDS * self.t_k);
-        let (sin_omega_tk, cos_omega_tk) = (constants::Omega::BDS * self.t_k).sin_cos();
-        let fd_rz = self.fd_omega_k
-            * na::Matrix3::new(
-                -sin_omega_tk,
-                cos_omega_tk,
-                0.0,
-                -cos_omega_tk,
-                -sin_omega_tk,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            );
-        let pos = self.beidou_geo_ecef_position();
-        let fd_pos = Vector3::new(fd_xgk, fd_ygk, fd_zgk);
-        let vel = fd_rz * rx * pos + rz * rx * fd_pos;
-        (pos, vel)
-    }
-
-    /// get ecef position
-    pub fn position(&self) -> Option<Vector3<f64>> {
-        match self.sv.constellation {
-            Constellation::GPS | Constellation::Galileo => Some(self.ecef_position()),
-            Constellation::BeiDou => {
-                if Constants::is_beidou_geo(self.sv) {
-                    Some(self.beidou_geo_ecef_position())
-                } else {
-                    Some(self.ecef_position())
-                }
-            },
-            _ => {
-                warn!("EphemerisHelper currently only supports orbit solutions for BDS GPS GALIEO");
-                None
-            },
-        }
+    pub(crate) fn ecef_pv(&self, almanac: &Almanac) -> (Vector3<f64>, Vector3<f64>) {
+        let orbit_ecef = almanac
+            .transform_to(self.orbit.unwrap(), IAU_EARTH_FRAME, None)
+            .unwrap();
+        (orbit_ecef.radius_km * 1e-3, orbit_ecef.velocity_km_s * 1e-3)
     }
 
     /// get ecef position and velocity
-    pub fn position_velocity(&self) -> Option<(Vector3<f64>, Vector3<f64>)> {
+    pub fn position_velocity(&self, almanac: &Almanac) -> Option<(Vector3<f64>, Vector3<f64>)> {
         match self.sv.constellation {
-            Constellation::GPS | Constellation::Galileo => Some(self.ecef_pv()),
-            Constellation::BeiDou => {
-                if Constants::is_beidou_geo(self.sv) {
-                    Some(self.beidou_geo_ecef_pv())
-                } else {
-                    Some(self.ecef_pv())
-                }
+            Constellation::GPS | Constellation::Galileo | Constellation::BeiDou => {
+                Some(self.ecef_pv(almanac))
             },
             _ => {
                 log::warn!(
@@ -410,8 +265,10 @@ impl Ephemeris {
         let gm = Constants::gm(sv);
         let omega = Constants::omega(sv);
         let dtr_f = Constants::dtr_f(sv);
-        let mut helper = EphemerisHelper::default();
-        helper.sv = sv;
+        let mut helper = EphemerisHelper {
+            sv,
+            ..Default::default()
+        };
         // set t_k
         if let Some(t_k) = self.tk(sv, t) {
             helper.t_k = t_k
@@ -489,6 +346,21 @@ impl Ephemeris {
         // Relativistic Effect Correction
         helper.dtr = dtr_f * kepler.e * kepler.a.sqrt() * e_k.sin();
         helper.fd_dtr = dtr_f * kepler.e * kepler.a.sqrt() * e_k.cos() * fd_e_k;
+
+        // Finally, build the orbit state
+        helper.orbit = Some(
+            Orbit::try_keplerian(
+                kepler.a,
+                kepler.e,
+                helper.i_k,
+                helper.omega_k,
+                helper.u_k,
+                v_k,
+                t,
+                EARTH_J2000,
+            )
+            .unwrap(),
+        );
 
         Some(helper)
     }
@@ -665,7 +537,9 @@ impl Ephemeris {
     /// See [Bibliography::AsceAppendix3], [Bibliography::JLe19] and [Bibliography::BeiDouICD]
     pub fn kepler2position(&self, sv: SV, t: Epoch) -> Option<(f64, f64, f64)> {
         let helper = self.ephemeris_helper(sv, t)?;
-        let pos = helper.position()?;
+        // Build the orbit in the Earth J2000 (inertial) frame.
+        // let orbit = Orbit::try_keplerian(kepler.a, kepler.e, inc, raan, aop, ta, epoch, frame)
+        let pos = helper.orbit?.radius_km;
         Some((pos.x / 1000.0, pos.y / 1000.0, pos.z / 1000.0))
     }
     /*
@@ -680,9 +554,10 @@ impl Ephemeris {
         &self,
         sv: SV,
         t: Epoch,
+        almanac: &Almanac,
     ) -> Option<((f64, f64, f64), (f64, f64, f64))> {
         let helper = self.ephemeris_helper(sv, t)?;
-        let (pos, vel) = helper.position_velocity()?;
+        let (pos, vel) = helper.position_velocity(almanac)?;
         Some((
             (pos.x / 1000.0, pos.y / 1000.0, pos.z / 1000.0),
             (vel.x, vel.y, vel.z),
@@ -716,6 +591,7 @@ impl Ephemeris {
         &self,
         sv: SV,
         epoch: Epoch,
+        almanac: &Almanac,
     ) -> Option<((f64, f64, f64), (f64, f64, f64))> {
         let (x_km, y_km, z_km, vx, vy, vz) = (
             self.get_orbit_f64("satPosX"),
@@ -733,7 +609,7 @@ impl Ephemeris {
                  */
                 Some(((x_km, y_km, z_km), (vx, vy, vz)))
             },
-            _ => self.kepler2position_velocity(sv, epoch),
+            _ => self.kepler2position_velocity(sv, epoch, almanac),
         }
     }
     /// Helper method to calculate elevation and azimuth angles, both in degrees,

--- a/sinex/Cargo.toml
+++ b/sinex/Cargo.toml
@@ -20,5 +20,4 @@ chrono = "0.4"
 thiserror = "1"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
-# gnss-rs = { version = "2.1.3", features = ["serde"] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+gnss-rs = { version = "2.2.0", features = ["serde"] }

--- a/sp3/Cargo.toml
+++ b/sp3/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--cfg", "docrs", "--generate-link-to-definition"]
 [dependencies]
 thiserror = "1"
 map_3d = "0.1.5"
-hifitime = { git = "https://github.com/nyx-space/hifitime.git", branch = "master" }
+hifitime = "4.0.0-alpha"
 # gnss-rs = { version = "2.1.3", features = ["serde"] }
 gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }

--- a/sp3/Cargo.toml
+++ b/sp3/Cargo.toml
@@ -25,8 +25,7 @@ rustdoc-args = ["--cfg", "docrs", "--generate-link-to-definition"]
 thiserror = "1"
 map_3d = "0.1.5"
 hifitime = "4.0.0-alpha"
-# gnss-rs = { version = "2.1.3", features = ["serde"] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+gnss-rs = { version = "2.2.0", features = ["serde"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 flate2 = { version = "1.0.24", optional = true, default-features = false, features = ["zlib"] }
 

--- a/ublox-rnx/Cargo.toml
+++ b/ublox-rnx/Cargo.toml
@@ -21,6 +21,5 @@ serde_json = "1.0"
 serialport = "4.2.0"
 ublox = "0.4.4"
 clap = { version = "4.4.10", features = ["derive", "color"] }
-# gnss-rs = { version = "2.1.3", features = ["serde"] }
-gnss-rs = { git = "https://github.com/rtk-rs/gnss", branch = "main", features = ["serde"] }
+gnss-rs = { version = "2.2.0", features = ["serde"] }
 rinex = { path = "../rinex", version = "=0.16.1", features = ["serde", "nav", "obs", "clock"] }


### PR DESCRIPTION
Following our conversation from https://github.com/orgs/nyx-space/discussions/310, I'm proposing switching to ANISE for the computation of the Earth centered Earth fixed (ECEF) position and velocity. Note that, in my experience with deep space navigation, we typically use only the "IAU Earth" or the augmented "ITRF93" frames: both are Earth centered Earth fixed frames, but they are more rigorously defined. The IAU Earth frame uses the precession, long term and short term nutation parameters defined [here](https://github.com/nyx-space/anise/blob/master/data/pck00008.tpc#L821). The ITRF93 frame is a frame reconstructed from the actual observations of the stars: it is more precise than the IAU Earth frame, but that precision is rarely needed for Earth orbiting spacecraft.

One of the main issues with the work I present here is that ... I've not been able to test it! I wasn't sure where to find some test code. This proposed change modifies the signature of the functions to require the addition of an Almanac.

In this specific case, because all of the GNSS spacecraft orbit the Earth, all you need to do is load the planetary constants kernel file (either version 08 or version 11, the Earth data did not change in between these). I recommend simply specifying the Almanac using a `MetaFile` as done here: https://github.com/rtk-rs/gnss-rtk/pull/16/files#diff-cbd16a2b1fdb7e2f39b676831dfaee5250000b403a9f1fcfcbfede424d7cbf73R220 .

Let me know if you have any questions! I'd like to test this together if possible because I want to check that my inputs to `try_keplerian` are correct, especially when it comes to the units.

P.S.: Sorry for the extra stuff that may have changed due to formatting, I've got a bunch of fixes done automatically for me because I'm too lazy to execute the formatting tool.