### PR TITLE
Fix CGGTTS error when the observation interval is 1 second

### DIFF
--- a/rinex-cli/src/positioning/cggtts/mod.rs
+++ b/rinex-cli/src/positioning/cggtts/mod.rs
@@ -313,11 +313,9 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
                             let next_release = next_release.unwrap();
                             let trk_midpoint = trk_midpoint.unwrap();
 
-                            if t >= next_release {
+                            if t > next_release {
                                 /* time to release a track */
                                 let ioe = 0; //TODO
-                                             // latch last measurement
-                                tracker.latch_measurement(t, fitdata);
 
                                 match tracker.fit(
                                     ioe,
@@ -389,6 +387,8 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
 
                                 // reset so we start a new track
                                 tracker.reset();
+                                // latch first measurement
+                                tracker.latch_measurement(t, fitdata);
                             }
                             // time to release a track
                             else {


### PR DESCRIPTION
I tried to use `rinex-cli` to create CGGTTS from RINEX, but it failed(not enough candidates match post-fit criteria). After some debugging, I found that the issue occurs when the observation interval is 1 second.

When the observation interval is 1 second, the line `if t >= next_release` is called twice within the same track, causing the track to be reset twice. (Note: `t == next_release`, but `sched.next_track_start(*t)` does not update `next_release`.)

I attempted to fix the bug, and the code now works. However, I am not sure if the measurements in the track are correct. Please review the code.

Thank you.
