### PR TITLE
Fix CGGTTS error when the observation interval is 1 second

### DIFF
--- a/rinex-cli/src/positioning/cggtts/mod.rs
+++ b/rinex-cli/src/positioning/cggtts/mod.rs
@@ -417,11 +417,8 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
         next_release = Some(sched.next_track_start(*t));
         // If the last epoch is reached, should release track
         let next_release_duration = next_release.unwrap() - *t;
-        should_release = (
-            next_release_duration <= dominant_sampling_period
-        ) && (
-            next_release_duration > Duration::ZERO
-        );
+        should_release = (next_release_duration <= dominant_sampling_period)
+            && (next_release_duration > Duration::ZERO);
         trk_midpoint = Some(next_release.unwrap() - trk_duration / 2);
         info!("{:?} - {} until next track", t, next_release.unwrap() - *t);
     } //.observations()

--- a/rinex-cli/src/positioning/cggtts/mod.rs
+++ b/rinex-cli/src/positioning/cggtts/mod.rs
@@ -94,6 +94,7 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
     let mut tracks = Vec::<Track>::new();
     let sched = Scheduler::new(trk_duration);
     let mut next_release = Option::<Epoch>::None;
+    let mut should_release = false;
     let mut trk_midpoint = Option::<Epoch>::None;
     let mut trackers = HashMap::<(SV, Observable), SVTracker>::new();
 
@@ -313,7 +314,7 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
                             let next_release = next_release.unwrap();
                             let trk_midpoint = trk_midpoint.unwrap();
 
-                            if t >= next_release {
+                            if should_release {
                                 /* time to release a track */
                                 let ioe = 0; //TODO
                                              // latch last measurement
@@ -414,6 +415,13 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
             } // for all OBS
         } //.sv()
         next_release = Some(sched.next_track_start(*t));
+        // If the last epoch is reached, should release track
+        let next_release_duration = next_release.unwrap() - *t;
+        should_release = (
+            next_release_duration <= dominant_sampling_period
+        ) && (
+            next_release_duration > Duration::ZERO
+        );
         trk_midpoint = Some(next_release.unwrap() - trk_duration / 2);
         info!("{:?} - {} until next track", t, next_release.unwrap() - *t);
     } //.observations()


### PR DESCRIPTION
I tried to use rinex-cli to create CGGTTS from RINEX, but it failed(not enough candidates match post-fit criteria). After some debugging, I found that the issue occurs when the observation interval is 1 second.

When the observation interval is 1 second, the line if t >= next_release is called twice within the same track, causing the track to be reset twice. (Note: t == next_release, but sched.next_track_start(*t) does not update next_release.)

I attempted to fix the bug, and the code now works. However, I am not sure if the measurements in the track are correct. Please review the code.

Thank you.