### PR TITLE
Fix track midpoint determination, in CGGTTS tracking

### DIFF
--- a/rinex-cli/src/positioning/cggtts/mod.rs
+++ b/rinex-cli/src/positioning/cggtts/mod.rs
@@ -23,6 +23,8 @@ use cggtts::{
     track::{FitData, GlonassChannel, SVTracker, Scheduler},
 };
 
+use hifitime::Unit;
+
 use crate::{
     cli::Context,
     positioning::{
@@ -419,7 +421,7 @@ pub fn resolve<'a, 'b, CK: ClockStateProvider, O: OrbitSource>(
         let next_release_duration = next_release.unwrap() - *t;
         should_release = (next_release_duration <= dominant_sampling_period)
             && (next_release_duration > Duration::ZERO);
-        trk_midpoint = Some(next_release.unwrap() - trk_duration / 2);
+        trk_midpoint = Some(next_release.unwrap() - (3.0 * 60.0 * Unit::Second) - trk_duration / 2);
         info!("{:?} - {} until next track", t, next_release.unwrap() - *t);
     } //.observations()
 


### PR DESCRIPTION
- [x] #285 

To test the tracker, I used `./tutorials/CGGTTS/mojndnk` focused on `E05+E09`

Results with current version:

![image](https://github.com/user-attachments/assets/72fb7d00-0249-4437-b87d-2f9b1d6c60ab)


Results with the proposal :

![image](https://github.com/user-attachments/assets/15aa8470-2bdc-48b6-9ac3-40c21b284284)


@vicalloy,

note that the CGGTTS scheduler is tested in cggtts/track/scheduler, for example the initial point in any day is tested thoroughly

![image](https://github.com/user-attachments/assets/720f4bce-44e8-46bf-9e2d-b5df89d0a1dc)


