### PR TITLE
Jpl gh 286

### DIFF
--- a/rinex-cli/src/cli/mod.rs
+++ b/rinex-cli/src/cli/mod.rs
@@ -114,6 +114,7 @@ to operate the RINEX/SP3/RTK toolkit, until a GUI is made available.
 Use it to analyze data, perform file operations and resolve navigation solutions.")
                     .arg_required_else_help(true)
                     .color(ColorChoice::Always)
+                    .next_help_heading("Context")
                     .arg(Arg::new("filepath")
                         .long("fp")
                         .value_name("FILE")
@@ -182,6 +183,13 @@ but you can extend that with --depth. Refer to -f for more information."))
 By default the $RINEX_WORKSPACE variable is prefered if it is defined.
 You can also use this flag to customize it. 
 If none are defined, we will then try to create a local directory named \"WORKSPACE\" like it is possible in this very repo."))
+                .arg(Arg::new("jpl-bpc")
+                    .long("jpl-bpc")
+                    .action(ArgAction::SetTrue)
+                    .help("Force update or request upgrade to highest precision JPL daily model.
+Requires internet access on each deployment!
+Once downloaded (updated) a model is valid for a couple of days or weeks, but you should regularly update
+to obtain highest precision."))
         .next_help_heading("Output customization")
         .arg(
             Arg::new("output-name")
@@ -481,5 +489,10 @@ Otherwise it gets automatically picked up."))
     /// Customized / manually defined output to be generated
     pub fn custom_output_name(&self) -> Option<&String> {
         self.matches.get_one::<String>("output-name")
+    }
+
+    /// True if jpl_bpc_update is requested
+    pub fn jpl_bpc_update(&self) -> bool {
+        self.matches.get_flag("jpl-bpc")
     }
 }

--- a/rinex-cli/src/main.rs
+++ b/rinex-cli/src/main.rs
@@ -73,8 +73,8 @@ fn user_data_parsing(
     max_depth: usize,
     is_rover: bool,
 ) -> QcContext {
-    let mut ctx =
-        QcContext::new().unwrap_or_else(|e| panic!("context setup issue: {}", e));
+    let mut ctx = QcContext::new(cli.jpl_bpc_update())
+        .unwrap_or_else(|e| panic!("failed to initialize a context: {}", e));
 
     // recursive dir loader
     for dir in directories.iter() {

--- a/rinex-cli/src/main.rs
+++ b/rinex-cli/src/main.rs
@@ -74,7 +74,7 @@ fn user_data_parsing(
     is_rover: bool,
 ) -> QcContext {
     let mut ctx =
-        QcContext::new().unwrap_or_else(|e| panic!("failed to initialize new context {}", e));
+        QcContext::new().unwrap_or_else(|e| panic!("context setup issue: {}", e));
 
     // recursive dir loader
     for dir in directories.iter() {

--- a/rinex-qc/README.md
+++ b/rinex-qc/README.md
@@ -36,9 +36,11 @@ When built with `flate2` support, gzip compressed files can be naturally loaded:
 ```rust
 use rinex_qc::prelude::*;
 
+
 // Build a setup
-// This will deploy with latest Almanac set for high performances
-let mut ctx = QcContext::new()
+// This will not deploy with latest Almanac set for highest performances
+let update_model = false;
+let mut ctx = QcContext::new(update_model)
     .unwrap();
 
 let cfg = QcConfig::default(); // basic
@@ -66,7 +68,8 @@ Once again, gzip compressed files are naturally supported when built with `flate
 use rinex_qc::prelude::*;
 
 // Build a setup
-let mut ctx = QcContext::new()
+let update_model = false;
+let mut ctx = QcContext::new(update_model)
     .unwrap();
 
 let cfg = QcConfig::default(); // basic
@@ -92,8 +95,11 @@ force the consideration (along SP3) by using a custom `QcConfig`:
 use rinex_qc::prelude::*;
 
 // Build a setup
-let mut ctx = QcContext::new()
+let update_model = false;
+
+let mut ctx = QcContext::new(update_model)
     .unwrap();
+
 let cfg = QcConfig::default(); // basic
 ```
 
@@ -101,14 +107,15 @@ let cfg = QcConfig::default(); // basic
 
 PPP compliant contexts are made of RINEX files and SP3 files, for the same time frame.
 The QcSummary report will let you know how compliant your input context is
-and what may restrict performances:
+and what may restrict performances. 
+
 
 ```rust
 use rinex_qc::prelude::*;
 
 // basic setup
-let mut ctx = QcContext::new().unwrap();
-let cfg = QcConfig::default();
+let update_model = false;
+let mut ctx = QcContext::new(update_model).unwrap();
 ```
 
 ## Custom chapters
@@ -118,8 +125,8 @@ Format your custom chapters as `QcExtraPage` so you can create your own report!
 ```rust
 use rinex_qc::prelude::*;
 
-let mut ctx = QcContext::new().unwrap();
-let cfg = QcConfig::default(); // basic setup
+let update_model = false;
+let mut ctx = QcContext::new(update_model).unwrap();
 ```
 
 ## More info


### PR DESCRIPTION
Fix offline/online deployment options
- [x] fixes #286 
- a new --jpl-bpc option is introduced in RINEX-Cli
  Which always requires internet access and IS THE ONLY OPTION
  to keep the JPL model up to date.
- the local storage is preserved and allows fast deployments
  (after a first successful deployment)
- for example, in the past few days the JPL servers have been down.
  
When deploying without --jpl-bpc:
  - the session will rely on the previous JPL model if it was already downloaded.
    If this model is too old and servers remain down, you should delete it !
   - the session will rely on low precision (offline) model until a JPL model
    has been obtained

When deploying with --jpl-bpc:
  - the session will crash because correct network access is expected
